### PR TITLE
feat(Components): introduce StatusLetterIdenticon

### DIFF
--- a/sandbox/Others.qml
+++ b/sandbox/Others.qml
@@ -13,4 +13,8 @@ GridLayout {
     StatusLoadingIndicator {
         color: parent.theme.directColor4
     }
+
+    StatusLetterIdenticon {
+        name: "#status"
+    }
 }

--- a/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.13
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+Rectangle {
+    id: statusLetterIdenticon
+
+    property string name
+    property int letterSize: 21
+
+    color: Theme.palette.miscColor5
+    width: 40
+    height: 40
+    radius: width / 2
+
+    StatusBaseText {
+        text: (statusLetterIdenticon.name.charAt(0) == "#" ? statusLetterIdenticon.name.charAt(1) : statusLetterIdenticon.name.charAt(0)).toUpperCase()
+        font.weight: Font.Bold
+        font.pixelSize: statusLetterIdenticon.letterSize
+        color: Qt.rgba(255, 255, 255, 0.7)
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+    }
+}
+
+

--- a/src/StatusQ/Components/qmldir
+++ b/src/StatusQ/Components/qmldir
@@ -1,3 +1,4 @@
 module StatusQ.Components
 
+StatusLetterIdenticon 0.1 StatusLetterIdenticon.qml
 StatusLoadingIndicator 0.1 StatusLoadingIndicator.qml


### PR DESCRIPTION
This introduces the `StatusLetterIdenticon` component to StatusQ.

Usage:

```
import StatusQ.Components 0.1

StatusLetterIdenticon {
    name: "#status"
}
```

Closes #28