### PR TITLE
fix(Core.Theme): ensure all font weight are available

### DIFF
--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -6,8 +6,64 @@ ThemePalette {
         source: "../../../assets/fonts/Inter/Inter-Regular.otf"
     }
 
+    property QtObject baseFontThin: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Thin.otf"
+    }
+
+    property QtObject baseFontExtraLight: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-ExtraLight.otf"
+    }
+
+    property QtObject baseFontLight: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Light.otf"
+    }
+
+    property QtObject baseFontMedium: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Medium.otf"
+    }
+
+    property QtObject baseFontBold: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Bold.otf"
+    }
+
+    property QtObject baseFontExtraBold: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-ExtraBold.otf"
+    }
+
+    property QtObject baseFontBlack: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Black.otf"
+    }
+
     property QtObject monoFont: FontLoader {
         source: "../../../assets/fonts/InterStatus/InterStatus-Regular.otf"
+    }
+
+    property QtObject monoFontThin: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Thin.otf"
+    }
+
+    property QtObject monoFontExtraLight: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraLight.otf"
+    }
+
+    property QtObject monoFontLight: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Light.otf"
+    }
+
+    property QtObject monoFontMedium: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Medium.otf"
+    }
+
+    property QtObject monoFontBold: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Bold.otf"
+    }
+
+    property QtObject monoFontExtraBold: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraBold.otf"
+    }
+
+    property QtObject monoFontBlack: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Black.otf"
     }
 
     baseColor1: getColor('graphite5')

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -6,9 +6,69 @@ ThemePalette {
         source: "../../../assets/fonts/Inter/Inter-Regular.otf"
     }
 
+    property QtObject baseFontThin: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Thin.otf"
+    }
+
+    property QtObject baseFontExtraLight: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-ExtraLight.otf"
+    }
+
+    property QtObject baseFontLight: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Light.otf"
+    }
+
+    property QtObject baseFontMedium: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Medium.otf"
+    }
+
+    property QtObject baseFontBold: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Bold.otf"
+    }
+
+    property QtObject baseFontExtraBold: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-ExtraBold.otf"
+    }
+
+    property QtObject baseFontBlack: FontLoader {
+        source: "../../../assets/fonts/Inter/Inter-Black.otf"
+    }
+
     property QtObject monoFont: FontLoader {
         source: "../../../assets/fonts/InterStatus/InterStatus-Regular.otf"
     }
+
+    property QtObject monoFontThin: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Thin.otf"
+    }
+
+    property QtObject monoFontExtraLight: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraLight.otf"
+    }
+
+    property QtObject monoFontLight: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Light.otf"
+    }
+
+    property QtObject monoFontMedium: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Medium.otf"
+    }
+
+    property QtObject monoFontBold: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Bold.otf"
+    }
+
+    property QtObject monoFontExtraBold: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraBold.otf"
+    }
+
+    property QtObject monoFontBlack: FontLoader {
+        source: "../../../assets/fonts/InterStatus/InterStatus-Black.otf"
+    }
+
+    baseColor1: getColor('grey5')
+    baseColor2: getColor('grey4')
+    baseColor3: getColor('grey3')
 
     baseColor1: getColor('grey5')
     baseColor2: getColor('grey4')

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -4,8 +4,23 @@ QtObject {
     
     id: theme
 
-    property QtObject baseFont
-    property QtObject monoFont
+    property FontLoader baseFont
+    property FontLoader baseFontThin
+    property FontLoader baseFontExtraLight
+    property FontLoader baseFontLight
+    property FontLoader baseFontMedium
+    property FontLoader baseFontBold
+    property FontLoader baseFontExtraBold
+    property FontLoader baseFontBlack
+
+    property FontLoader monoFont
+    property FontLoader monoFontThin
+    property FontLoader monoFontExtraLight
+    property FontLoader monoFontLight
+    property FontLoader monoFontMedium
+    property FontLoader monoFontBold
+    property FontLoader monoFontExtraBold
+    property FontLoader monoFontBlack
 
     property color baseColor1
     property color baseColor2


### PR DESCRIPTION
Turns out, even though we only use one and the same `font.family` name
throughout our components (namely `Inter` and/or `InterStatus`),
`font.weight` properties set to anything other than `Font.Normal` (which is the default),
will not apply unless all font weights have actually been loaded.

Unfortunately we can put a `FontLoader` as direct child in a `ThemePalette`
so we have to make it actual properties.

These properties aren't really used anywhere and merely serve as a place
to load font assets.

Fixes #30