### PR TITLE
feat(Core.Theme): expose solid black and white on `ThemePalette`

### DIFF
--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -22,6 +22,9 @@ QtObject {
     property FontLoader monoFontExtraBold
     property FontLoader monoFontBlack
 
+    property color black: getColor('black')
+    property color white: getColor('white')
+
     property color baseColor1
     property color baseColor2
     property color baseColor3


### PR DESCRIPTION
Status color palettes don't specify a solid black and white that stay
black and white in both themes.

This commit introduces `black` and `white` as solid colors to `ThemePalette`
so they are automatically inherited in all built-in and custom themes.