### PR TITLE
feat(Layout): introduce StatusAppLayout component

### DIFF
--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -119,6 +119,10 @@ ThemePalette {
     miscColor10: getColor('brown3')
     miscColor11: getColor('yellow2')
 
+    property QtObject statusAppLayout: QtObject {
+        property color backgroundColor: baseColor3
+    }
+
     property QtObject statusAppNavBar: QtObject {
         property color backgroundColor: baseColor5
     }

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -119,6 +119,10 @@ ThemePalette {
     miscColor10: getColor('brown')
     miscColor11: getColor('brown2')
 
+    property QtObject statusAppLayout: QtObject {
+        property color backgroundColor: white
+    }
+
     property QtObject statusAppNavBar: QtObject {
         property color backgroundColor: baseColor4
     }

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -80,6 +80,10 @@ QtObject {
     property color miscColor10
     property color miscColor11
 
+    property QtObject statusAppLayout: QtObject {
+        property color backgroundColor
+    }
+
     property QtObject statusAppNavBar: QtObject {
         property color backgroundColor
     }

--- a/src/StatusQ/Layout/StatusAppLayout.qml
+++ b/src/StatusQ/Layout/StatusAppLayout.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.13
+import QtQuick.Layouts 1.13
+import QtQuick.Controls 2.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+Rectangle {
+    id: statusAppLayout
+
+    implicitWidth: 900
+    implicitHeight: 600
+
+    color: Theme.palette.statusAppLayout.backgroundColor
+    
+    property StatusAppNavBar appNavBar
+    property Item appView
+
+    onAppNavBarChanged: {
+        if (!!appNavBar) {
+            appNavBar.parent = appNavBarSlot
+        }
+    }
+
+    onAppViewChanged: {
+        if (!!appView) {
+            appView.parent = appViewSlot
+        }
+    }
+
+    Row {
+        id: rowLayout
+        spacing: 0
+        height: statusAppLayout.height
+        width: statusAppLayout.width
+
+        Item {
+            id: appNavBarSlot
+            height: statusAppLayout.height
+            width: 78
+        }
+
+        Item {
+            id: appViewSlot
+            height: statusAppLayout.height
+            width: statusAppLayout.width - appNavBarSlot.width
+        }
+    }
+}

--- a/src/StatusQ/Layout/qmldir
+++ b/src/StatusQ/Layout/qmldir
@@ -1,5 +1,6 @@
 module StatusQ.Layout
 
+StatusAppLayout 0.1 StatusAppLayout.qml
 StatusAppNavBar 0.1 StatusAppNavBar.qml
 
 


### PR DESCRIPTION
This introduces a layout component to quickly scaffold a Status Desktop
ui layout.

Usage:

```qml
import StatusQ.Layout 0.1

StatusAppLayout {
    appNavBar: StatusAppNavBar { ... }
    appView: StackView {
        anchors.fill: parent
        initialItem: Component { ... }
    }
}
```

Closes: #77