### PR TITLE
fix(Core): don't rotate `ColorOverlay` of `StatusIcon`

### DIFF
--- a/src/StatusQ/Core/StatusIcon.qml
+++ b/src/StatusQ/Core/StatusIcon.qml
@@ -25,7 +25,6 @@ Image {
         color: statusIcon.color
         antialiasing: true
         smooth: true
-        rotation: statusIcon.rotation
     }
 }
 


### PR DESCRIPTION
As discussed in #109, when using the `rotation` property of `StatusIcon`
it seems to just mirror the underlying image source.

It turns out that using `rotation` on the image source is enough to have
the `ColorOverlay` rotate as well. Adding a `rotation` to the overlay will
rotate the source that's already rotated, resulting in a mirrored result.

To fix this, we're removing the additional `rotation` from the overlay.

Fixes #109