### PR TITLE
feat(StatusListItem) expose content children and introduce padding pr…

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -127,42 +127,22 @@ Rectangle {
             leftPanel: Item {
                 anchors.fill: parent
 
-                Column {
+                StatusChatList {
                     anchors.top: parent.top
                     anchors.topMargin: 64
                     anchors.horizontalCenter: parent.horizontalCenter
 
-                    spacing: 4
-
-                    StatusChatListItem {
-                        name: "#status"
-                        type: StatusChatListItem.Type.PublicChat
+                    selectedChatId: "0"
+                    chatListItems.model: demoChatListItems
+                    onChatItemSelected: selectedChatId = id
+                    onChatItemUnmuted: {
+                        for (var i = 0; i < demoChatListItems.count; i++) {
+                            let item = demoChatListItems.get(i);
+                            if (item.chatId === id) {
+                                demoChatListItems.setProperty(i, "muted", false)
+                            }
+                        }
                     }
-
-                    StatusChatListItem {
-                        name: "#status-desktop"
-                        type: StatusChatListItem.Type.PublicChat
-                        hasUnreadMessages: true
-                        badge.value: 1
-                    }
-
-                    StatusChatListItem {
-                        name: "Amazing Funny Squirrel"
-                        type: StatusChatListItem.Type.OneToOneChat
-                        selected: true
-                    }
-
-                    StatusChatListItem {
-                        name: "Black Ops"
-                        type: StatusChatListItem.Type.GroupChat
-                    }
-
-                    StatusChatListItem {
-                        name: "Spectacular Growling Otter"
-                        type: StatusChatListItem.Type.OneToOneChat
-                        muted: true
-                    }
-
                 }
             }
 
@@ -261,6 +241,57 @@ Rectangle {
                     chatInfoButton.type: StatusChatInfoButton.Type.CommunityChat
                 }
             }
+        }
+    }
+
+    ListModel {
+        id: demoChatListItems
+        ListElement {
+            chatId: "0"
+            name: "#status"
+            chatType: StatusChatListItem.Type.PublicChat
+            muted: false
+            hasUnreadMessages: false
+            hasMention: false
+            unreadMessagesCount: 0
+            iconColor: "blue"
+        }
+        ListElement {
+            chatId: "1"
+            name: "#status-desktop"
+            chatType: StatusChatListItem.Type.PublicChat
+            muted: false
+            hasUnreadMessages: true
+            iconColor: "red"
+            unreadMessagesCount: 1
+        }
+        ListElement {
+            chatId: "2"
+            name: "Amazing Funny Squirrel"
+            chatType: StatusChatListItem.Type.OneToOneChat
+            muted: false
+            hasUnreadMessages: false
+            iconColor: "green"
+            identicon: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
+            unreadMessagesCount: 0
+        }
+        ListElement {
+            chatId: "3"
+            name: "Black Ops"
+            chatType: StatusChatListItem.Type.GroupChat
+            muted: false
+            hasUnreadMessages: false
+            iconColor: "purple"
+            unreadMessagesCount: 0
+        }
+        ListElement {
+            chatId: "4"
+            name: "Spectacular Growing Otter"
+            chatType: StatusChatListItem.Type.OneToOneChat
+            muted: true
+            hasUnreadMessages: false
+            iconColor: "Orange"
+            unreadMessagesCount: 0
         }
     }
 }

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+Column {
+    id: statusChatList
+
+    spacing: 4
+
+    property string selectedChatId: ""
+    property alias chatListItems: statusChatListItems
+
+    signal chatItemSelected(string id)
+    signal chatItemUnmuted(string id)
+
+    Repeater {
+        id: statusChatListItems
+        delegate: StatusChatListItem {
+            chatId: model.chatId
+            name: model.name
+            type: model.chatType
+            muted: !!model.muted
+            hasUnreadMessages: !!model.hasUnreadMessages
+            hasMention: !!model.hasMention
+            badge.value: model.unreadMessagesCount || 0
+            selected: model.chatId === statusChatList.selectedChatId
+
+            icon.color: model.iconColor || ""
+            image.source: model.identicon || ""
+
+            onClicked: statusChatList.chatItemSelected(model.chatId)
+            onUnmute: statusChatList.chatItemUnmuted(model.chatId)
+        }
+    }
+}

--- a/src/StatusQ/Components/StatusChatListItem.qml
+++ b/src/StatusQ/Components/StatusChatListItem.qml
@@ -7,6 +7,7 @@ import StatusQ.Controls 0.1
 Rectangle {
     id: statusChatListItem
 
+    property string chatId: ""
     property string name: ""
     property alias badge: statusBadge
     property bool hasUnreadMessages: false

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -15,6 +15,8 @@ Rectangle {
 
     property string title: ""
     property string subTitle: ""
+    property real leftPadding: 16
+    property real rightPadding: 16
     property StatusIconSettings icon: StatusIconSettings {
         height: 20
         width: 20
@@ -26,6 +28,10 @@ Rectangle {
     }
     property StatusImageSettings image: StatusImageSettings {}
     property string label: ""
+
+    property alias sensor: sensor
+    property alias statusListItemTitle: statusListItemTitle
+    property alias statusListItemComponentsSlot: statusListItemComponentsSlot
 
     property list<Item> components
 
@@ -47,7 +53,7 @@ Rectangle {
         Loader {
             id: iconOrImage
             anchors.left: parent.left
-            anchors.leftMargin: 16
+            anchors.leftMargin: statusListItem.leftPadding
             anchors.verticalCenter: parent.verticalCenter
             sourceComponent: !!statusListItem.icon.name ? statusRoundedIcon : statusRoundedImage
             active: !!statusListItem.icon.name || !!statusListItem.image.source.toString()
@@ -74,7 +80,7 @@ Rectangle {
 
         Item {
             anchors.left: iconOrImage.active ? iconOrImage.right : parent.left
-            anchors.leftMargin: 16
+            anchors.leftMargin: statusListItem.leftPadding
             anchors.verticalCenter: parent.verticalCenter
             height: statusListItemTitle.height + (statusListItemSubTitle.visible ? statusListItemSubTitle.height : 0)
 
@@ -111,7 +117,7 @@ Rectangle {
         Row {
             id: statusListItemComponentsSlot
             anchors.right: parent.right
-            anchors.rightMargin: 16
+            anchors.rightMargin: statusListItem.rightPadding
             anchors.verticalCenter: parent.verticalCenter
             spacing: 10
         }

--- a/src/StatusQ/Components/qmldir
+++ b/src/StatusQ/Components/qmldir
@@ -1,6 +1,7 @@
 module StatusQ.Components
 
 StatusBadge 0.1 StatusBadge.qml
+StatusChatList 0.1 StatusChatList.qml
 StatusChatListItem 0.1 StatusChatListItem.qml
 StatusChatToolBar 0.1 StatusChatToolBar.qml
 StatusDescriptionListItem 0.1 StatusDescriptionListItem.qml

--- a/src/StatusQ/Core/StatusIconSettings.qml
+++ b/src/StatusQ/Core/StatusIconSettings.qml
@@ -9,5 +9,6 @@ QtObject {
     property real height
     property color color
     property url source
+    property int rotation
     property StatusIconBackgroundSettings background: StatusIconBackgroundSettings {}
 }


### PR DESCRIPTION
…operties

These properties are needed to enable more control over how a list
item implementation can look like.

Content children are exposed as follows:

```qml
StatusListItem {
    statusListItemTitle.[...]: ... // StatusBaseText
    sensor.[...]: ... // MouseArea

    rightPadding: ... // default 16
    leftPadding: .. // default 16
}
```