### PR TITLE
 feat(Components): introduce `StatusChatListCategory`

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -210,20 +210,56 @@ Rectangle {
                     anchors.horizontalCenter: parent.horizontalCenter
                     spacing: 4
 
-                    StatusChatListCategoryItem {
-                        id: publicCategory
-                        title: "Public"
-                        onClicked: opened = !opened
-                        onToggleButtonClicked: opened = !opened
+                    StatusChatList {
+                        id: statusChatList
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        chatListItems.model: demoCommunityChatListItems
                     }
 
-                    StatusChatList {
-                        anchors.horizontalCenter: parent.horizontalCenter
+                    StatusChatListCategory {
+                        name: "Public"
 
-                        selectedChatId: "0"
-                        chatListItems.model: demoCommunityChatListItems
-                        onChatItemSelected: selectedChatId = id
-                        visible: publicCategory.opened
+                        chatList.chatListItems.model: demoCommunityChatListItems
+                        chatList.selectedChatId: "0"
+                        chatList.onChatItemSelected: chatList.selectedChatId = id
+                        popupMenu: categoryPopupCmp
+                    }
+
+                    StatusChatListCategory {
+                        name: "Development"
+
+                        chatList.chatListItems.model: demoCommunityChatListItems
+                        chatList.onChatItemSelected: chatList.selectedChatId = id
+                        popupMenu: categoryPopupCmp
+                    }
+                }
+
+                Component {
+                    id: categoryPopupCmp
+
+                    StatusPopupMenu {
+                        StatusMenuItem {
+                            text: "Mute Category"
+                            icon.name: "notification"
+                        }
+
+                        StatusMenuItem { 
+                            text: "Mark as Read"
+                            icon.name: "checkmark-circle"
+                        }
+
+                        StatusMenuItem { 
+                            text: "Edit Category"
+                            icon.name: "edit"
+                        }
+
+                        StatusMenuSeparator {}
+
+                        StatusMenuItem {
+                            text: "Delete Category"
+                            icon.name: "delete"
+                            type: StatusMenuItem.Type.Danger
+                        }
                     }
                 }
             }

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -1,0 +1,60 @@
+import QtQuick 2.13
+
+import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
+
+Column {
+    id: statusChatListCategory
+
+    spacing: 0
+
+    property string categoryId: ""
+    property string name: ""
+    property bool opened: true
+
+    property alias addButton: statusChatListCategoryItem.addButton
+    property alias menuButton: statusChatListCategoryItem.menuButton
+    property alias toggleButton: statusChatListCategoryItem.toggleButton
+    property alias chatList: statusChatList
+
+    property Component popupMenu
+
+    onPopupMenuChanged: {
+        if (!!popupMenu) {
+            popupMenuSlot.sourceComponent = popupMenu
+        }
+    }
+
+    StatusChatListCategoryItem {
+        id: statusChatListCategoryItem
+        title: statusChatListCategory.name
+        opened: statusChatListCategory.opened
+
+        onClicked: statusChatListCategory.opened = !opened
+        onToggleButtonClicked: statusChatListCategory.opened = !opened
+        onMenuButtonClicked: {
+            highlighted = true
+            menuButton.highlighted = true
+            popupMenuSlot.item.popup()
+        }
+    }
+
+    StatusChatList {
+        id: statusChatList
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        visible: statusChatListCategory.opened
+    }
+
+    Loader {
+        id: popupMenuSlot
+        active: !!statusChatListCategory.popupMenu
+        onLoaded: {
+            popupMenuSlot.item.closeHandler = function () {
+                statusChatListCategoryItem.highlighted = false
+                statusChatListCategoryItem.menuButton.highlighted = false
+            }
+        }
+    }
+}
+

--- a/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -15,6 +15,7 @@ StatusListItem {
     rightPadding: 8
 
     property bool opened: true
+    property bool highlighted: false
     property alias addButton: addButton
     property alias menuButton: menuButton
     property alias toggleButton: toggleButton
@@ -24,7 +25,7 @@ StatusListItem {
     signal menuButtonClicked(var mouse)
     signal toggleButtonClicked(var mouse)
 
-    color: sensor.containsMouse ? Theme.palette.baseColor2 : "transparent"
+    color: sensor.containsMouse || highlighted ? Theme.palette.baseColor2 : "transparent"
 
     sensor.onClicked: statusChatListCategoryItem.clicked(mouse)
 
@@ -38,7 +39,7 @@ StatusListItem {
             id: addButton
             icon.name: "add"
             icon.width: 20
-            visible: statusChatListCategoryItem.sensor.containsMouse
+            visible: statusChatListCategoryItem.sensor.containsMouse || statusChatListCategoryItem.highlighted
             onClicked: statusChatListCategoryItem.addButtonClicked(mouse)
             tooltip.text: "Add channel inside category"
         },
@@ -46,7 +47,7 @@ StatusListItem {
             id: menuButton
             icon.name: "more"
             icon.width: 21
-            visible: statusChatListCategoryItem.sensor.containsMouse
+            visible: statusChatListCategoryItem.sensor.containsMouse || statusChatListCategoryItem.highlighted
             onClicked: statusChatListCategoryItem.menuButtonClicked(mouse)
             tooltip.text: "More"
         },

--- a/src/StatusQ/Components/qmldir
+++ b/src/StatusQ/Components/qmldir
@@ -3,6 +3,7 @@ module StatusQ.Components
 StatusBadge 0.1 StatusBadge.qml
 StatusChatList 0.1 StatusChatList.qml
 StatusChatListItem 0.1 StatusChatListItem.qml
+StatusChatListCategory 0.1 StatusChatListCategory.qml
 StatusChatListCategoryItem 0.1 StatusChatListCategoryItem.qml
 StatusChatToolBar 0.1 StatusChatToolBar.qml
 StatusDescriptionListItem 0.1 StatusDescriptionListItem.qml

--- a/src/StatusQ/Controls/StatusChatListCategoryItemButton.qml
+++ b/src/StatusQ/Controls/StatusChatListCategoryItemButton.qml
@@ -8,13 +8,14 @@ StatusFlatRoundButton {
     width: 22
     radius: 4
 
+    property bool highlighted: false
     property alias tooltip: statusToolTip
 
     type: StatusFlatRoundButton.Type.Secondary
     icon.width: 20
     icon.color: Theme.palette.directColor4
 
-    color: hovered ? 
+    color: hovered || highlighted ? 
         Theme.palette.statusChatListCategoryItem.buttonHoverBackgroundColor : 
         "transparent"
 

--- a/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -16,6 +16,13 @@ Menu {
 
     property int menuItemCount: 0
     property var subMenuItemIcons: []
+    property var closeHandler
+
+    onClosed: {
+        if (typeof closeHandler === "function") {
+            closeHandler()
+        }
+    }
 
     delegate: MenuItem {
         id: statusPopupMenuItem


### PR DESCRIPTION
A component used to render chat list groups.

Usage:

```qml
import StatusQ.Components 0.1

StatusChatListCategory {
    categoryId: ...
    name: "Public"
    opened: true // default `true`

    addButton.[...]: ... // `StatusChatListCategoryItemButton`
    menuButton.[...]: ... // `StatusChatListCategoryItemButton`
    toggleButton.[...]: ... // `StatusChatListCategoryItemButton`

    chatList.chatListItems.model: ... // `chatsList` is a `StatusChatList`
    chatList.selectedChatId: ...
    chatList.onChatItemSelected: ...

    popupMenu: StatusPopupMenu {
        ...
    }
}
```

Closes #123
