### PR TITLE
fix(StatusAppNavBar): don't rely on `undefined` property

### DIFF
--- a/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -79,7 +79,7 @@ Rectangle {
                 bottomPadding = 16
                 topPadding = 16
             } else {
-                height = navBarCommunityTabButtonsSlot.implicitHeight
+                height = navBarCommunityTabButtons.count > 0 ? navBarCommunityTabButtonsSlot.implicitHeight : 0
             }
         }
 
@@ -107,7 +107,7 @@ Rectangle {
         height: 1
         width: 30
         color: Theme.palette.directColor7
-        anchors.top: navBarCommunityTabButtons.model && navBarCommunityTabButtons.model.count > 0 ? navBarScrollSection.bottom : navBarChatButtonSlot.bottom
+        anchors.top: !!navBarCommunityTabButtons.model && navBarCommunityTabButtons.count > 0 ? navBarScrollSection.bottom : navBarChatButtonSlot.bottom
         anchors.topMargin: navBarScrollSection.height < navBarCommunityTabButtonsSlot.implicitHeight ? 0 : 16
         anchors.horizontalCenter: parent.horizontalCenter
         visible: navBarChatButton !== null && navBarTabButtons.length > 0


### PR DESCRIPTION
This turned out to be a bug. `model.count` isn't defined on `Repeater`
types.

Also, set `ScrollView` height to `0` if there are not community
tab buttons. This is needed because the columns implicit height
comes with spacing, resulting in some height.