### PR TITLE
feat(StatusPopupMenu): introduce `openHandler`

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -250,7 +250,7 @@ Rectangle {
 
                     StatusChatListCategory {
                         name: "Public"
-
+                        showActionButtons: true
                         chatList.chatListItems.model: demoCommunityChatListItems
                         chatList.selectedChatId: "0"
                         chatList.onChatItemSelected: chatList.selectedChatId = id
@@ -260,6 +260,7 @@ Rectangle {
                     StatusChatListCategory {
                         name: "Development"
 
+                        showActionButtons: true
                         chatList.chatListItems.model: demoCommunityChatListItems
                         chatList.onChatItemSelected: chatList.selectedChatId = id
                         popupMenu: categoryPopupCmp

--- a/sandbox/ListItems.qml
+++ b/sandbox/ListItems.qml
@@ -40,10 +40,17 @@ GridLayout {
     StatusChatListCategoryItem {
         title: "Chat list category"
         opened: false
+        showActionButtons: true
     }
 
     StatusChatListCategoryItem {
         title: "Chat list category (opened)"
+        opened: true
+        showActionButtons: true
+    }
+
+    StatusChatListCategoryItem {
+        title: "Chat list category (no buttons)"
         opened: true
     }
 

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -12,6 +12,7 @@ Column {
     property string name: ""
     property bool opened: true
 
+    property alias showActionButtons: statusChatListCategoryItem.showActionButtons
     property alias addButton: statusChatListCategoryItem.addButton
     property alias menuButton: statusChatListCategoryItem.menuButton
     property alias toggleButton: statusChatListCategoryItem.toggleButton

--- a/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -16,6 +16,7 @@ StatusListItem {
 
     property bool opened: true
     property bool highlighted: false
+    property bool showActionButtons: false
     property alias addButton: addButton
     property alias menuButton: menuButton
     property alias toggleButton: toggleButton
@@ -39,7 +40,9 @@ StatusListItem {
             id: addButton
             icon.name: "add"
             icon.width: 20
-            visible: statusChatListCategoryItem.sensor.containsMouse || statusChatListCategoryItem.highlighted
+            visible: statusChatListCategoryItem.showActionButtons && 
+                (statusChatListCategoryItem.highlighted ||
+                statusChatListCategoryItem.sensor.containsMouse)
             onClicked: statusChatListCategoryItem.addButtonClicked(mouse)
             tooltip.text: "Add channel inside category"
         },
@@ -47,7 +50,9 @@ StatusListItem {
             id: menuButton
             icon.name: "more"
             icon.width: 21
-            visible: statusChatListCategoryItem.sensor.containsMouse || statusChatListCategoryItem.highlighted
+            visible: statusChatListCategoryItem.showActionButtons && 
+                (statusChatListCategoryItem.highlighted ||
+                statusChatListCategoryItem.sensor.containsMouse)
             onClicked: statusChatListCategoryItem.menuButtonClicked(mouse)
             tooltip.text: "More"
         },

--- a/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -16,7 +16,14 @@ Menu {
 
     property int menuItemCount: 0
     property var subMenuItemIcons: []
+    property var openHandler
     property var closeHandler
+
+    onOpened: {
+        if (typeof openHandler === "function") {
+            openHandler()
+        }
+    }
 
     onClosed: {
         if (typeof closeHandler === "function") {


### PR DESCRIPTION
Similar to `closeHandler`, StatusPopupMenu can now have a customized `openHandler`
to run custom logic on open.