### PR TITLE
feat(StatusChatList): introduce `profileImageFn` property

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -18,6 +18,7 @@ Column {
     property Component popupMenu
 
     property var filterFn
+    property var profileImageFn
 
     signal chatItemSelected(string id)
     signal chatItemUnmuted(string id)
@@ -42,7 +43,13 @@ Column {
             selected: model.chatId === statusChatList.selectedChatId
 
             icon.color: model.color || ""
-            image.source: model.identicon || ""
+            image.source: {
+                let profileImage = ""
+                if (typeof statusChatList.profileImageFn === "function") {
+                    profileImage = statusChatList.profileImageFn(model.chatId || model.id)
+                }
+                return profileImage || model.identityImage || model.identicon || ""
+            }
 
             onClicked: {
                 if (mouse.button === Qt.RightButton && !!statusChatList.popupMenu) {


### PR DESCRIPTION
This property enables users to pass as factory function to `StatusChatList`
component that determines the profile image of a given chat id.

Usage:

```qml
import StatusQ.Components 0.1

StatusChatList {
    ...
    profileImageFn: function (id) {
        // `id` is the model id of the current chat item iterator
        return ... // has to return a profile image url
    }
}
```

In addition to this property, this commit also makes the component
expect an optional `model.identityImage` in case it's already provided.
That way, `profileImageFn` can be omitted.

Closes #174