### PR TITLE
feat(StatusRoundedImage): introduce identicon support

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -684,7 +684,8 @@ Rectangle {
             muted: false
             hasUnreadMessages: false
             color: "green"
-            identicon: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
+            identicon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0Bh
+CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
             unreadMessagesCount: 0
         }
         ListElement {

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -32,7 +32,17 @@ Column {
     Repeater {
         id: statusChatListItems
         delegate: StatusChatListItem {
+
             id: statusChatListItem
+
+            property string profileImage: ""
+
+            Component.onCompleted: {
+                if (typeof statusChatList.profileImageFn === "function") {
+                    profileImage = statusChatList.profileImageFn(model.chatId || model.id) || ""
+                }
+            }
+
             chatId: model.chatId || model.id
             name: model.name
             type: model.chatType
@@ -43,13 +53,8 @@ Column {
             selected: model.chatId === statusChatList.selectedChatId
 
             icon.color: model.color || ""
-            image.source: {
-                let profileImage = ""
-                if (typeof statusChatList.profileImageFn === "function") {
-                    profileImage = statusChatList.profileImageFn(model.chatId || model.id)
-                }
-                return profileImage || model.identityImage || model.identicon || ""
-            }
+            image.isIdenticon: !!!profileImage && !!!model.identityImage && !!model.identicon
+            image.source: profileImage || model.identityImage || model.identicon || ""
 
             onClicked: {
                 if (mouse.button === Qt.RightButton && !!statusChatList.popupMenu) {

--- a/src/StatusQ/Components/StatusChatListItem.qml
+++ b/src/StatusQ/Components/StatusChatListItem.qml
@@ -88,6 +88,11 @@ Rectangle {
                     height: parent.height
                     image.source: statusChatListItem.image.source
                     showLoadingIndicator: true
+                    color: statusChatListItem.image.isIdenticon ?
+                        Theme.palette.statusRoundedImage.backgroundColor :
+                        "transparent"
+                    border.width: statusChatListItem.image.isIdenticon ? 1 : 0
+                    border.color: Theme.palette.directColor7
                 }
 
                 Loader {

--- a/src/StatusQ/Core/StatusImageSettings.qml
+++ b/src/StatusQ/Core/StatusImageSettings.qml
@@ -6,5 +6,6 @@ QtObject {
     property url source
     property real width
     property real height
+    property bool isIdenticon: false
 }
 

--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -168,5 +168,9 @@ ThemePalette {
     property QtObject statusModal: QtObject {
         property color backgroundColor: baseColor3
     }
+
+    property QtObject statusRoundedImage: QtObject {
+        property color backgroundColor: baseColor3
+    }
 }
 

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -166,5 +166,9 @@ ThemePalette {
     property QtObject statusModal: QtObject {
         property color backgroundColor: white
     }
+
+    property QtObject statusRoundedImage: QtObject {
+        property color backgroundColor: white
+    }
 }
 

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -130,6 +130,10 @@ QtObject {
         property color backgroundColor
     }
 
+    property QtObject statusRoundedImage: QtObject {
+        property color backgroundColor
+    }
+
     function alphaColor(color, alpha) {
         let actualColor = Qt.darker(color, 1)
         actualColor.a = alpha


### PR DESCRIPTION
This just introduces a new `StatusImageSettings` property `isIdenticon`
which can be used to determine whether a `StatusRoundedImage` should
render with a background + border (which is the case for identicons).

It also updates the `StatusChatList` delegate to consider that property
and have it properly decide how to render the UI.

Closes #173