### PR TITLE
feat(StatusModal): expose loaded content

### DIFF
--- a/sandbox/Popups.qml
+++ b/sandbox/Popups.qml
@@ -33,6 +33,11 @@ Column {
         onClicked: modalExample.open()
     }
 
+    StatusButton {
+        text: "Modal with changable content"
+        onClicked: modalWithContentAccess.open()
+    }
+
     StatusModal {
         id: simpleModal
         anchors.centerIn: parent
@@ -141,5 +146,29 @@ Column {
             icon.height: 20
             icon.name: "info"
         }
+    }
+
+    StatusModal {
+        id: modalWithContentAccess
+        anchors.centerIn: parent
+        header.title: "Header"
+        header.subTitle: "SubTitle"
+
+        content: StatusBaseText {
+            id: text
+            anchors.centerIn: parent
+            text: "Some text content"
+            font.pixelSize: 15
+            color: Theme.palette.directColor1
+        }
+
+        rightButtons: [
+            StatusButton {
+                text: "Change text"
+                onClicked: {
+                    modalWithContentAccess.contentComponent.text = "Changed!"
+                }
+            }
+        ]
     }
 }

--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -16,6 +16,7 @@ QC.Popup {
     property alias headerActionButton: headerImpl.actionButton
 
     property StatusModalHeaderSettings header: StatusModalHeaderSettings {}
+    property alias contentComponent: contentLoader.item
     property alias rightButtons: footerImpl.rightButtons
     property alias leftButtons: footerImpl.leftButtons
 
@@ -56,6 +57,7 @@ QC.Popup {
         }
 
         Loader {
+            id: contentLoader
             active: true
             anchors.horizontalCenter: parent.horizontalCenter
             sourceComponent: statusModal.content


### PR DESCRIPTION
As discussed in #237, this is needed for consumers to access content
children from outside `content`.

Usage:

```qml
StatusModal {
  id: modal
  content: StatusBaseText {
      text: "Foo"
  }

  rightButtons: [
      StatusButton {
          text: "Change text"
          onClicked: {
              modal.contentComponent.text = "Bar"
          }
      }
  ]
}
```

Fixes #237