### PR TITLE
feat(StatusChatToolBar): add members and search button

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -255,6 +255,8 @@ Rectangle {
                     chatInfoButton.type: StatusChatInfoButton.Type.OneToOneChat
                     chatInfoButton.pinnedMessagesCount: 1
 
+                    searchButton.visible: false
+                    membersButton.visible: false
                     notificationCount: 1
 
                     onNotificationButtonClicked: notificationCount = 0

--- a/src/StatusQ/Components/StatusChatToolBar.qml
+++ b/src/StatusQ/Components/StatusChatToolBar.qml
@@ -14,6 +14,8 @@ Rectangle {
     property alias chatInfoButton: statusChatInfoButton
     property alias menuButton: menuButton
     property alias notificationButton: notificationButton
+    property alias membersButton: membersButton
+    property alias searchButton: searchButton
     property int notificationCount: 0
 
     property Component popupMenu
@@ -21,6 +23,8 @@ Rectangle {
     signal chatInfoButtonClicked()
     signal menuButtonClicked()
     signal notificationButtonClicked()
+    signal membersButtonClicked()
+    signal searchButtonClicked()
 
     onPopupMenuChanged: {
         if (!!popupMenu) {
@@ -45,6 +49,24 @@ Rectangle {
         spacing: 8
 
         StatusFlatRoundButton {
+            id: searchButton
+            width: 32
+            height: 32
+            icon.name: "search"
+            type: StatusFlatRoundButton.Type.Secondary
+            onClicked: statusChatToolBar.searchButtonClicked()
+        }
+
+        StatusFlatRoundButton {
+            id: membersButton
+            width: 32
+            height: 32
+            icon.name: "group-chat"
+            type: StatusFlatRoundButton.Type.Secondary
+            onClicked: statusChatToolBar.membersButtonClicked()
+        }
+
+        StatusFlatRoundButton {
             id: menuButton
             width: 32
             height: 32
@@ -55,8 +77,17 @@ Rectangle {
             onClicked: {
                 statusChatToolBar.menuButtonClicked()
                 highlighted = true
-                let p = menuButton.mapToItem(statusChatToolBar, menuButton.x, menuButton.y)
-                popupMenuSlot.item.popup(p.x + menuButton.width - popupMenuSlot.item.width, p.y + 4 + menuButton.height)
+                popupMenuSlot.item.popup(-popupMenuSlot.item.width + menuButton.width, menuButton.height + 4)
+            }
+
+            Loader {
+                id: popupMenuSlot
+                active: !!statusChatToolBar.popupMenu
+                onLoaded: {
+                    popupMenuSlot.item.closeHandler = function () {
+                        menuButton.highlighted = false
+                    }
+                }
             }
         }
 
@@ -65,7 +96,8 @@ Rectangle {
             width: 1
             color: Theme.palette.directColor7
             anchors.verticalCenter: parent.verticalCenter
-            visible: menuButton.visible && notificationButton.visible
+            visible: notificationButton.visible &&
+                (menuButton.visible || membersButton.visible || searchButton.visible)
         }
 
         StatusFlatRoundButton {
@@ -102,16 +134,6 @@ Rectangle {
             }
         }
 
-    }
-
-    Loader {
-        id: popupMenuSlot
-        active: !!statusChatToolBar.popupMenu
-        onLoaded: {
-            popupMenuSlot.item.closeHandler = function () {
-                menuButton.highlighted = false
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This commit adds the members and search button which are needed for certain
features in Status Desktop. In views where these aren't needed, each button
can be set `visible: false` individually:

```qml
StatusChatToolBar {
    ...
    membersButton.visible: false
    searchButton.visible: false
}
```

Closes #243