### PR TITLE
feat(StatusModal): render header and footer border by default

### DIFF
--- a/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
+++ b/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
@@ -5,6 +5,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
 
 
 Rectangle {
@@ -65,5 +66,11 @@ Rectangle {
         width: parent.width
         height: parent.radius
         color: parent.color
+
+        StatusModalDivider {
+            visible: (statusModalFooter.leftButtons.length || statusModalFooter.rightButtons.length) && rootLayout.height > 1
+            anchors.top: parent.top
+            width: parent.width
+        }
     }
 }

--- a/src/StatusQ/Popups/statusModal/StatusModalHeader.qml
+++ b/src/StatusQ/Popups/statusModal/StatusModalHeader.qml
@@ -4,6 +4,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
 
 Rectangle {
     id: statusModalHeader
@@ -66,5 +67,10 @@ Rectangle {
         width: parent.width
         height: parent.radius
         color: parent.color
+
+        StatusModalDivider {
+            anchors.bottom: parent.bottom
+            width: parent.width
+        }
     }
 }


### PR DESCRIPTION
This adds a `StatusModalDivider` to the header and footer so they don't
have to be put into `content` and therefore won't scroll out of the viewport
if the content exceeds the modal height.

The footer divider is only rendered when there's indeed action buttons
provided.

Closes #265