### PR TITLE
feat(StatusToolTip): expose `arrow` for fine-grain control

### DIFF
--- a/src/StatusQ/Components/StatusChatToolBar.qml
+++ b/src/StatusQ/Components/StatusChatToolBar.qml
@@ -159,6 +159,7 @@ Rectangle {
                 text: "Activity"
                 orientation: StatusToolTip.Orientation.Bottom
                 y: parent.height + 12
+                arrow.x: width - (parent.width-4)
             }
         }
 

--- a/src/StatusQ/Controls/StatusToolTip.qml
+++ b/src/StatusQ/Controls/StatusToolTip.qml
@@ -15,6 +15,7 @@ ToolTip {
 
     property int maxWidth: 800
     property int orientation: StatusToolTip.Orientation.Top
+    property alias arrow: arrow
 
     implicitWidth: Math.min(maxWidth, textContent.implicitWidth + 16)
     leftPadding: 8
@@ -32,6 +33,7 @@ ToolTip {
             anchors.bottomMargin: 8
         }
         Rectangle {
+            id: arrow
             color: statusToolTipContentBackground.color
             height: 20
             width: 20


### PR DESCRIPTION
There's cases where the arrow on the tooltip needs to be repositioned, for example
when the tooltip doesn't fit into the viewport anymore but is centered below a button.