### PR TITLE
feat(Popups): introduce `StatusMenuHeadline` component

### DIFF
--- a/src/StatusQ/Popups/StatusMenuHeadline.qml
+++ b/src/StatusQ/Popups/StatusMenuHeadline.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+MenuSeparator {
+    id: root
+    property string text
+    height: visible && enabled ? implicitHeight : 0
+    contentItem: Item {
+        implicitWidth: 176
+        implicitHeight: 16
+        StatusBaseText {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 12
+            color: Theme.palette.baseColor1
+            font.pixelSize: 12
+            text: root.text
+        }
+    }
+}
+

--- a/src/StatusQ/Popups/qmldir
+++ b/src/StatusQ/Popups/qmldir
@@ -3,5 +3,6 @@ module StatusQ.Popups
 StatusMenuSeparator 0.1 StatusMenuSeparator.qml
 StatusPopupMenu 0.1 StatusPopupMenu.qml
 StatusMenuItem 0.1 StatusMenuItem.qml
+StatusMenuHeadline 0.1 StatusMenuHeadline.qml
 StatusModal 0.1 StatusModal.qml
 StatusModalDivider 0.1 StatusModalDivider.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -15,6 +15,7 @@
         <file>src/StatusQ/Popups/qmldir</file>
         <file>src/StatusQ/Popups/StatusPopupMenu.qml</file>
         <file>src/StatusQ/Popups/StatusMenuSeparator.qml</file>
+        <file>src/StatusQ/Popups/StatusMenuHeadline.qml</file>
         <file>src/StatusQ/Popups/StatusMenuItem.qml</file>
         <file>src/StatusQ/Popups/StatusModalDivider.qml</file>
         <file>src/StatusQ/Components/qmldir</file>


### PR DESCRIPTION
This component can be used to group different sections within a popup menu.

Usage:

```qml
StatusPopupMenu {

    StatusMenuItem {
        text: "One"
        icon.name: "info"
    }

    StatusMenuHeadline {
        text: "Some text"
    }

    StatusMenuItem {
        text: "Two"
        icon.name: "info"
    }
}
```