### PR TITLE
feat(StatusPopupMenu): add support for letter identicons, identicons …

### DIFF
--- a/sandbox/StatusPopupMenuPage.qml
+++ b/sandbox/StatusPopupMenuPage.qml
@@ -22,6 +22,13 @@ GridLayout {
         onClicked: complexMenu.popup()
     }
 
+
+    StatusButton {
+        text: "Menu with custom images and icons"
+        onClicked: customMenu.popup()
+    }
+
+
     StatusPopupMenu {
         id: simpleMenu
         StatusMenuItem { 
@@ -40,32 +47,103 @@ GridLayout {
     StatusPopupMenu {
         id: complexMenu
         subMenuItemIcons: ['info']
+
         StatusMenuItem { 
             text: "One" 
-            icon.name: "info"
+            iconSettings.name: "info"
         }
 
         StatusMenuSeparator {}
 
         StatusMenuItem { 
             text: "Two"
-            icon.name: "info"
+            iconSettings.name: "info"
         }
 
         StatusMenuItem { 
             text: "Three"
-            icon.name: "info"
+            iconSettings.name: "info"
         }
 
         StatusPopupMenu {
             title: "Four"
             StatusMenuItem { 
                 text: "One"
-                icon.name: "info"
+                iconSettings.name: "info"
             }
             StatusMenuItem { 
                 text: "Three"
-                icon.name: "info"
+                iconSettings.name: "info"
+            }
+        }
+    }
+
+    StatusPopupMenu {
+        id: customMenu
+
+        subMenuItemIcons: [
+            "chat", 
+            { 
+                source: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg" 
+            },
+            { 
+                isLetterIdenticon: true, 
+                color: "red" 
+            }
+        ]
+
+        StatusMenuItem {
+            text: "Anywhere"
+        }
+
+        StatusMenuSeparator {}
+
+        StatusPopupMenu {
+            title: "Chat" 
+
+            StatusMenuItem { 
+                text: "vitalik.eth"
+                image.source: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0Bh
+CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
+                image.isIdenticon: true
+            }
+
+            StatusMenuItem { 
+                text: "Pascal"
+                image.source: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
+            }
+        }
+
+        StatusPopupMenu {
+            title: "Cryptokitties"
+
+            StatusMenuItem { 
+                text: "welcome" 
+                iconSettings.name: "channel"
+                iconSettings.color: Theme.palette.directColor1
+            }
+            StatusMenuItem { 
+                text: "support" 
+                iconSettings.name: "channel"
+                iconSettings.color: Theme.palette.directColor1
+            }
+
+            StatusMenuHeadline { text: "Public" }
+
+            StatusMenuItem { 
+                text: "news" 
+                iconSettings.name: "channel"
+                iconSettings.color: Theme.palette.directColor1
+            }
+        }
+
+        StatusPopupMenu {
+            title: "Another community"
+
+            StatusMenuItem { 
+                text: "welcome" 
+                iconSettings.isLetterIdenticon: true
+                iconSettings.background.color: "red"
             }
         }
     }

--- a/src/StatusQ/Popups/StatusMenuHeadline.qml
+++ b/src/StatusQ/Popups/StatusMenuHeadline.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+MenuSeparator {
+    id: root
+    property string text
+    height: visible && enabled ? implicitHeight : 0
+    contentItem: Item {
+        implicitWidth: 176
+        implicitHeight: 16
+        StatusBaseText {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: 12
+            color: Theme.palette.baseColor1
+            font.pixelSize: 12
+            text: root.text
+        }
+    }
+}
+

--- a/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/src/StatusQ/Popups/StatusMenuItem.qml
@@ -9,7 +9,17 @@ Action {
         Normal,
         Danger
     }
-
+    icon.color: "transparent"
     property int type: StatusMenuItem.Type.Normal
     property real iconRotation: 0
+    property StatusImageSettings image: StatusImageSettings {
+        height: 16
+        width: 16
+        isIdenticon: false
+    }
+    property StatusIconSettings iconSettings: StatusIconSettings {
+        isLetterIdenticon: false
+        background: StatusIconBackgroundSettings {}
+        color: "transparent"
+    }
 }

--- a/src/StatusQ/Popups/qmldir
+++ b/src/StatusQ/Popups/qmldir
@@ -3,5 +3,6 @@ module StatusQ.Popups
 StatusMenuSeparator 0.1 StatusMenuSeparator.qml
 StatusPopupMenu 0.1 StatusPopupMenu.qml
 StatusMenuItem 0.1 StatusMenuItem.qml
+StatusMenuHeadline 0.1 StatusMenuHeadline.qml
 StatusModal 0.1 StatusModal.qml
 StatusModalDivider 0.1 StatusModalDivider.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -15,6 +15,7 @@
         <file>src/StatusQ/Popups/qmldir</file>
         <file>src/StatusQ/Popups/StatusPopupMenu.qml</file>
         <file>src/StatusQ/Popups/StatusMenuSeparator.qml</file>
+        <file>src/StatusQ/Popups/StatusMenuHeadline.qml</file>
         <file>src/StatusQ/Popups/StatusMenuItem.qml</file>
         <file>src/StatusQ/Popups/StatusModalDivider.qml</file>
         <file>src/StatusQ/Components/qmldir</file>


### PR DESCRIPTION
…and images

This extends the popup menu to accept image or icon configurations a la `StatusIconSettings`
and `StatusImageSettings` in menu items, as well as nested menus.

Usage:

```qml
StatusPopupMenu {

    StatusMenuItem {
        text: "Custom Image icon"
        image.source: // image source
    }

    StatusMenuItem {
        text: "Custom identicon icon"
        image.source: // identicon source
        image.isIdenticon: true
    }

    StatusMenuItem {
        text: "Custom letter identicon"
        iconSettings.isLetterIdenticon: true
        iconSettings.background.color: "red"
    }
}
```

Few things to note:

- Because `StatusMenuItem` is an `Action` type, we can't extend its `icon` property,
  so we have to introduce our own (`iconSettings`) which can be of type `StatusIconSettings`
- Where possible, `StatusPopupMenu` will prefer `iconSettings.[...]` over `icon.[...]`,
  which means, both would work: `icon.name` and `iconSettings.name`.
  This is for consistency's sake. Consumers can switch completely to `iconSettings` if desired.
- When `isLetterIdenticon` is true, `iconSettings.background.color` must be set, similar
  to how it work in any other StatusQ component that makes use of this configuration type.

Closes #263