### PR TITLE
feat(StatusQ.Theme.Core): introduce theme colors for StatusChatInput

### DIFF
--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -172,5 +172,9 @@ ThemePalette {
     property QtObject statusRoundedImage: QtObject {
         property color backgroundColor: baseColor3
     }
+
+    property QtObject statusChatInput: QtObject {
+        property color secondaryBackgroundColor: "#414141"
+    }
 }
 

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -170,5 +170,9 @@ ThemePalette {
     property QtObject statusRoundedImage: QtObject {
         property color backgroundColor: white
     }
+
+    property QtObject statusChatInput: QtObject {
+        property color secondaryBackgroundColor: "#E2E6E8"
+    }
 }
 

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -134,6 +134,10 @@ QtObject {
         property color backgroundColor
     }
 
+    property QtObject statusChatInput: QtObject {
+        property color secondaryBackgroundColor
+    }
+
     function alphaColor(color, alpha) {
         let actualColor = Qt.darker(color, 1)
         actualColor.a = alpha


### PR DESCRIPTION
There's some usage specific color being added to the chat input (which doesn't live in
StatusQ yet). To make sure we don't lose that change, I'm adding the new
colors to StatusQ theming system and have Status Desktop use it for the time being
until `StatusChatInput` is moved to StatusQ anyways.