### PR TITLE
Status form control validator pipeline

### DIFF
--- a/sandbox/StatusInputPage.qml
+++ b/sandbox/StatusInputPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.14
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 
 import Sandbox 0.1
 
@@ -64,6 +65,22 @@ Column {
         input.clearable: true
         input.valid: false
         input.placeholderText: "Placeholder"
+    }
+
+    StatusInput {
+        label: "Label"
+        charLimit: 30
+        input.placeholderText: "Input with validator"
+
+        validators: [
+            StatusMinLengthValidator { minLength: 10 }
+        ]
+
+        onTextChanged: {
+            if (errors && errors.minLength) {
+                errorMessage = `Value can't be shorter than ${errors.minLength.min} but got ${errors.minLength.actual}`
+            }
+        }
     }
 
     StatusInput {

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -3,6 +3,7 @@ import QtQuick 2.14
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 
 Item {
     id: root
@@ -22,9 +23,14 @@ Item {
                   0) + 8
 
     property alias input: statusBaseInput
+    property alias valid: statusBaseInput.valid
+    property alias text: statusBaseInput.text
     property string label: ""
     property int charLimit: 0
     property string errorMessage: ""
+    property list<StatusValidator> validators
+
+    property var errors: ({})
 
     StatusBaseText {
         id: label
@@ -68,6 +74,24 @@ Item {
         anchors.rightMargin: 16
 
         maximumLength: root.charLimit
+
+        onTextChanged: {
+            if (root.validators.length) {
+                for (let idx in root.validators) {
+                    let result = root.validators[idx].validate(statusBaseInput.text)
+
+                    if (typeof result === "boolean" && result) {
+                        statusBaseInput.valid = true
+                    } else {
+                        if (!root.errors) {
+                            root.errors = {}
+                        }
+                        root.errors[root.validators[idx].name] = result
+                        statusBaseInput.valid = false
+                    }
+                }
+            }
+        }
     }
 
     StatusBaseText {

--- a/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
@@ -1,0 +1,16 @@
+import StatusQ.Controls 0.1
+
+StatusValidator {
+
+    property int minLength: 0
+
+    name: "minLength"
+
+    validate: function (value) {
+        return value.length >= minLength ? true : {
+            min: minLength,
+            actual: value.length
+        }
+    }
+}
+

--- a/src/StatusQ/Controls/Validators/StatusValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusValidator.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.13
+
+QtObject {
+    id: statusValidator
+
+    property string name: ""
+
+    property var validate: function (value) {
+        return true
+    }
+}

--- a/src/StatusQ/Controls/Validators/qmldir
+++ b/src/StatusQ/Controls/Validators/qmldir
@@ -1,0 +1,5 @@
+module StatusQ.Controls.Validators
+
+StatusValidator 0.1 StatusValidator.qml
+StatusMinLengthValidator 0.1 StatusMinLengthValidator.qml
+StatusMaxLengthValidator 0.1 StatusMaxLengthValidator.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -50,6 +50,8 @@
         <file>src/StatusQ/Controls/StatusCheckBox.qml</file>
         <file>src/StatusQ/Controls/StatusButton.qml</file>
         <file>src/StatusQ/Controls/StatusToolTip.qml</file>
+        <file>src/StatusQ/Controls/Validators/StatusValidator.qml</file>
+        <file>src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml</file>
         <file>src/StatusQ/Layout/StatusAppNavBar.qml</file>
         <file>src/StatusQ/Layout/qmldir</file>
         <file>src/StatusQ/Layout/StatusAppTwoPanelLayout.qml</file>


### PR DESCRIPTION
Here's what the draft is doing.

### New validators API for StatusInput to apply validators declaratively

There's a new `validators` property that can be used to add validators to `StatusInput` instances, which are executed in the same order:

```qml
StatusInput {
  text: "Some value"
  validators: [...]
}
```

### Built-in validators

For convenience StatusQ provides some common validation methods, such as `StatusMinLengthValidator`, StatusMaxLengthValidator` and could be extended to other (e.g. email validation etc):

```qml
StatusInput {
  text: "Some value"
  validators: [
    StatusMinLengthValidator { minLength: 3 }
  ]
}
```

### Validators execution and errors

Validators are executed every time the text of the input changes. They are executed in the same order they have been applied, which enables users to create cascading conditions like "First make sure the value is at least 3 characters long, then make sure it matches a certain pattern".

When a validation fails, it sets the validity of the input (`valid: false`) accordingly and optionally exposes additional error information on `StatusInput.errors`:

```qml
StatusInput {
  text: "Fo"
  onTextChanged: {
    if (errors) {
      /**
       * errors now has the following structure:
       * errors: {
       *   minLength: { minValue: 3, actual: ... }
       * }
       * Also, `StatusInput` is now `valid = false`
       **/ 
       errorMesssage = "Expected " + errors.minLenght.minValue + " but got: "+ errors.minLength.actual; // i18n'able
    }
  }
  validators: [
    StatusMinLengthValidator { minLength: 3 }
  ]
}
```
There can be any number of error objects on the `errors` property, depending on who many validators have been run that failed validation.

### Custom validators

Custom validators can be implemented by introducing a new `StatusValidator` type that has to implement a `validate()` function and defines the validators name. The `validate()` function has to return either `true` or `false` depending on whether the value is valid.

Alternatively, the function can return an error object which gets exposed on the underlying input's `errors` property, at which point it's considered invalid as well.

Here's a simple custom validator:

```qml
// HelloValidator.qml
import StatusQ.Controls.Validators 0.1

StatusValidator {

  property string name: "hello"

  validate: function (value) { // `value` is the `text` value of the underlying control
    return value === "hello"
  }
}
```

Applying this validators would look like this:

```qml
StatusInput {
  text: "Some value"
  validators: [
    HelloValidator {}
  ]
  onTextChanged: {
    if (errors.hello) {
      errorMessage = "Doesn't say hello!"
    }
  }
}
```

Alternatively, validators can return error objects to provide more information about what went wrong. Here's the implementation of the `StatusMinLengthValidator` as an example:

```qml
StatusValidator {

    property int minLength: 0

    name: "minLength"

    validate: function (value) {
        return value.length >= minLength ? true : {
            min: minLength,
            actual: value.length
        }
    }
}
```

Because validators as components, they can hold any custom properties they need to be configured.

### Maintaining error messages

There has been concern that, with this API, error messages need to be potentially defined in multiple places, given that there could be multiple instances of any validator. This is easily solved by having a centralized function figure out what the error message is, given a certain error object:

```qml
StatusInput {
  validators: [
    StatusMinLengthValidator { minLength: 3 }
  ]
  onTextChanged: {
    if (errors) {
      errorMessage = getErrorMessage(errors) // this function is provided by global or elsewhere
    }
  }
}
```