### PR TITLE
fix(StatusChatToolBar) Fixing more menu not closing

### DIFF
--- a/src/StatusQ/Components/StatusChatToolBar.qml
+++ b/src/StatusQ/Components/StatusChatToolBar.qml
@@ -88,10 +88,17 @@ Rectangle {
             type: StatusFlatRoundButton.Type.Secondary
             visible: !!statusChatToolBar.popupMenu
 
+            property bool showMoreMenu: false
             onClicked: {
-                statusChatToolBar.menuButtonClicked()
+                if (showMoreMenu) {
+                    popupMenuSlot.item.popup(-popupMenuSlot.item.width + menuButton.width, menuButton.height + 4)
+                }
                 highlighted = true
-                popupMenuSlot.item.popup(-popupMenuSlot.item.width + menuButton.width, menuButton.height + 4)
+                statusChatToolBar.menuButtonClicked()
+            }
+
+            onPressed: {
+                showMoreMenu = !showMoreMenu;
             }
 
             StatusToolTip {


### PR DESCRIPTION
The menu has a CloseOnReleaseOutside policy and so it
was closing and immediately re-opened when the kebab icon
was clicked since it's outside the menu area and also was
calling the popup function of the menu. Added dummy bool
property to detect whether the menu is already closed and
not open it again

Closes #308