### PR TITLE
fix(@desktop/chat) Acitvity tooltip arrow position is incorrect when members list is shown

### DIFF
--- a/src/StatusQ/Components/StatusChatToolBar.qml
+++ b/src/StatusQ/Components/StatusChatToolBar.qml
@@ -17,6 +17,8 @@ Rectangle {
     property alias membersButton: membersButton
     property alias searchButton: searchButton
     property int notificationCount: 0
+    // Used to understand if the tooltip is in the corner of the screen
+    property bool isCorner: true
 
     property Component popupMenu
 
@@ -166,7 +168,7 @@ Rectangle {
                 text: "Activity"
                 orientation: StatusToolTip.Orientation.Bottom
                 y: parent.height + 12
-                arrow.x: width - (parent.width-4)
+                cornerToolTip: isCorner
             }
         }
 

--- a/src/StatusQ/Controls/StatusToolTip.qml
+++ b/src/StatusQ/Controls/StatusToolTip.qml
@@ -13,6 +13,7 @@ ToolTip {
         Right
     }
 
+    property bool cornerToolTip: false
     property int maxWidth: 800
     property int orientation: StatusToolTip.Orientation.Top
     property alias arrow: arrow
@@ -41,7 +42,7 @@ ToolTip {
             radius: 1
             x: {
                 if (orientation === StatusToolTip.Orientation.Top || orientation === StatusToolTip.Orientation.Bottom) {
-                    return statusToolTipBackground.width / 2 - width / 2
+                    return cornerToolTip ? (statusToolTip.x + statusToolTip.width) : (statusToolTipBackground.width / 2 - arrow.width / 2)
                 }
                 if (orientation === StatusToolTip.Orientation.Left) {
                     return statusToolTipContentBackground.width - (width / 2) - 8


### PR DESCRIPTION
Added a property to check if a tool tip is a corner tool tip and in that case arrow position will be measured differently.

fixes #3102