### PR TITLE
feat(StatusBaseInput): enforce `maximumLength` if it's set

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -39,6 +39,7 @@ Item {
 
     property real minimumHeight: 0
     property real maximumHeight: 0
+    property int maximumLength: 0
 
     property bool valid: true
 
@@ -128,17 +129,17 @@ Item {
 
                 TextEdit {
                     id: edit
+                    property string previousText: text
+
                     width: flick.width
                     selectByMouse: true
                     selectionColor: Theme.palette.primaryColor2
                     selectedTextColor: color
                     anchors.verticalCenter: parent.verticalCenter
                     focus: true
-
                     font.pixelSize: 15
                     font.family: Theme.palette.baseFont.name
                     color: Theme.palette.directColor1
-
                     onCursorRectangleChanged: flick.ensureVisible(cursorRectangle)
                     wrapMode: TextEdit.NoWrap
 
@@ -155,6 +156,21 @@ Item {
                             event.accepted = false
                         } else {
                             event.accepted = true
+                        }
+                    }
+
+                    onTextChanged: {
+                        if (statusBaseInput.maximumLength > 0) {
+                            if (text.length > statusBaseInput.maximumLength) {
+                                var cursor = cursorPosition;
+                                text = previousText;
+                                if (cursor > text.length) {
+                                    cursorPosition = text.length;
+                                } else {
+                                    cursorPosition = cursor-1;
+                                }
+                            }
+                            previousText = text
                         }
                     }
 

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -66,6 +66,8 @@ Item {
         anchors.topMargin: charLimitLabel.visible ? 11 : 8
         anchors.leftMargin: 16
         anchors.rightMargin: 16
+
+        maximumLength: root.charLimit
     }
 
     StatusBaseText {


### PR DESCRIPTION
Prior to this commit, setting `charLimit` on `StatusInput` would only have a visual effect
(rendering the char limit), however it wouldn't actually enforce this limit.

This was by intended behaviour, because we wanted to leave some room
for possible validators to kick in (for example a max length validator).

If however the char limit is enforce, such a validator would never kick in.
There seems to be consensus in the team that the limit should be enforced though.

This commit enables that.