### PR TITLE
feat(StatusPopupMenu): changed close policy

### DIFF
--- a/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -10,7 +10,7 @@ import StatusQ.Popups 0.1
 
 Menu {
     id: statusPopupMenu
-    closePolicy: Popup.CloseOnReleaseOutsideParent | Popup.CloseOnEscape
+    closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
     topPadding: 8
     bottomPadding: 8
 


### PR DESCRIPTION
Close on press outside added to closing policy as the I found old one to be buggy on mac. Causes no side effects.