### PR TITLE
fix(StatusChatListCategory): emit original mouse event data in clicke…

### DIFF
--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -34,7 +34,7 @@ Column {
 
         showMenuButton: showActionButtons && !!statusChatListCategory.popupMenu
 
-        onClicked: {
+        sensor.onClicked: {
             if (mouse.button === Qt.RightButton && showActionButtons && !!statusChatListCategory.popupMenu) {
                 highlighted = true
                 popupMenuSlot.item.popup(mouse.x + 4, mouse.y + 6)
@@ -42,6 +42,8 @@ Column {
             }
             statusChatListCategory.opened = !opened
         }
+
+        onTitleClicked: statusChatListCategory.opened = !opened
         onToggleButtonClicked: statusChatListCategory.opened = !opened
         onMenuButtonClicked: {
             highlighted = true


### PR DESCRIPTION
…d signal

This fixes a bug that was introduced in https://github.com/status-im/StatusQ/commit/01da7508995de15e45703262e97b60f84fe64c03 with a breaking change
where `StatusChatListCategoryItem`'s `clicked` signal would no longer receive
a `mouse` event object.

The reason this is happening is because we've introduced a new `clicked` signal
on `StatusListItem`. The idea was to rely on that within `StatusChatListCategoryItem`,
however, we didn't take into account that the new `clicked` signal in `StatusListItem`
doesn't emit a `mouse` event object.

To fix this issue could either reintroduce the custom `clicked` handler on
`StatusChatListCategoryItem`, or listen to the original `sensor.onClicked` and
`onTitleClicked` signals exposed by `StatusListItem` instead, ensuring the required
`mouse` event data exists.

Fixes #333