### PR TITLE
fix(StatusListItem): don't set width on title item

### DIFF
--- a/sandbox/ListItems.qml
+++ b/sandbox/ListItems.qml
@@ -291,6 +291,11 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
 
     StatusListItem {
         title: "Title"
+        titleAsideText: "test"
+    }
+
+    StatusListItem {
+        title: "Title"
         icon.name: "delete"
         type: StatusListItem.Type.Danger
     }

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -179,8 +179,6 @@ Rectangle {
             StatusBaseText {
                 id: statusListItemTitle
                 text: statusListItem.title
-                width: contentWidth < (parent.width - statusListItemTitleAsideText.contentWidth) ?
-                       contentWidth : (parent.width - statusListItemTitleAsideText.contentWidth)
                 font.pixelSize: 15
                 height: visible ? contentHeight : 0
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere


### PR DESCRIPTION
There was an explicit `width` introduced on `statusListItemTitle`, most likely
to make room for it when `titleAsideText` is supplied.

This unfortunately causes the title get a very small width, resulting in broken
UI.

Since we can assume that there should be enough space for the titleAsideText
when it's used, we probably don't have to calculate a fixed width for the title
in the first place.

This commit therefore removes that explicit setting.