### PR TITLE
feat(StatusSearchPopup): add function hook to allow timestamp formatting

### DIFF
--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -28,6 +28,10 @@ StatusModal {
     signal resultItemClicked(string itemId)
     signal resultItemTitleClicked(string titleId)
 
+    property var formatTimestampFn: function (ts) {
+        return ts
+    }
+
     function setSearchSelection(text = "",
                                 secondaryText = "",
                                 imageSource = "",
@@ -291,7 +295,7 @@ StatusModal {
                         statusListItemSubTitle.color: Theme.palette.black
                         icon.isLetterIdenticon: (model.image === "")
                         icon.background.color: model.color
-                        titleAsideText: model.time
+                        titleAsideText: root.formatTimestampFn(model.time)
                         image.source: model.image
                         badge.primaryText: model.badgePrimaryText
                         badge.secondaryText: model.badgeSecondaryText


### PR DESCRIPTION
This introduces a new API to allow users to provide a function that formats
timestamps in the search results.

```qml
StatusSearchPopup {
  formatTimestampFn: function (ts) {
      return // formatted ts
  }
}
```

Closes #363