### PR TITLE
feat(StatusQ.Controls): introduce StatusSwitchTabBar and StatusSwitchTab

### DIFF
--- a/sandbox/StatusTabSwitchPage.qml
+++ b/sandbox/StatusTabSwitchPage.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.13
+
+import StatusQ.Controls 0.1
+
+GridLayout {
+    columns: 1
+    columnSpacing: 5
+    rowSpacing: 5
+
+    StatusSwitchTabBar {
+        StatusSwitchTab {
+            text: "Swap"
+        }
+        StatusSwitchTab {
+            text: "Swap & Send"
+        }
+        StatusSwitchTab {
+            text: "Send"
+        }
+    }
+}
+

--- a/sandbox/StatusTabSwitchPage.qml
+++ b/sandbox/StatusTabSwitchPage.qml
@@ -10,13 +10,13 @@ GridLayout {
     rowSpacing: 5
 
     StatusSwitchTabBar {
-        StatusSwitchTab {
+        StatusSwitchTabButton {
             text: "Swap"
         }
-        StatusSwitchTab {
+        StatusSwitchTabButton {
             text: "Swap & Send"
         }
-        StatusSwitchTab {
+        StatusSwitchTabButton {
             text: "Send"
         }
     }

--- a/sandbox/main.qml
+++ b/sandbox/main.qml
@@ -139,6 +139,11 @@ StatusWindow {
                             onClicked: page.sourceComponent = buttonsComponent
                         }
                         StatusNavigationListItem { 
+                            title: "StatusSwitchTab" 
+                            selected: page.sourceComponent == statusTabSwitchesComponent
+                            onClicked: page.sourceComponent = statusTabSwitchesComponent
+                        }
+                        StatusNavigationListItem { 
                             title: "Controls" 
                             selected: page.sourceComponent == controlsComponent
                             onClicked: page.sourceComponent = controlsComponent
@@ -279,6 +284,11 @@ StatusWindow {
     Component {
         id: statusModalComponent
         Popups {}
+    }
+
+    Component {
+        id: statusTabSwitchesComponent
+        StatusTabSwitchPage {}
     }
 
     Component {

--- a/src/StatusQ/Controls/StatusSwitchTab.qml
+++ b/src/StatusQ/Controls/StatusSwitchTab.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtGraphicalEffects 1.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+TabButton {
+    id: control
+    contentItem: Item {
+        height: 36
+        MouseArea {
+            id: sensor
+            hoverEnabled: true
+            anchors.fill: parent
+            cursorShape: control.hovered ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: control.checked = true
+
+            StatusBaseText {
+                id: label
+                text: control.text
+                color: Theme.palette.primaryColor1
+                font.weight: Font.Medium
+                font.pixelSize: 15
+                horizontalAlignment: Text.AlignHCenter
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    background: Rectangle {
+        id: controlBackground
+        implicitHeight: 36
+        implicitWidth: 148
+        color: control.checked ? 
+            Theme.palette.statusSwitchTab.backgroundColor :
+            "transparent"
+        radius: 8
+        layer.enabled: true
+        layer.effect: DropShadow {
+            width: controlBackground.width
+            height: controlBackground.height
+            x: controlBackground.x
+            source: controlBackground
+            horizontalOffset: 0
+            verticalOffset: 0
+            radius: 10
+            samples: 25
+            spread: 0
+            color: Theme.palette.dropShadow
+        }
+    }
+}

--- a/src/StatusQ/Controls/StatusSwitchTabBar.qml
+++ b/src/StatusQ/Controls/StatusSwitchTabBar.qml
@@ -3,14 +3,12 @@ import QtQuick.Controls 2.14
 import StatusQ.Core.Theme 0.1
 
 TabBar {
-    id: control
+    id: statusSwitchTabBar
     padding: 1
 
     background: Rectangle {
         implicitHeight: 36
         color: Theme.palette.directColor7
         radius: 8
-        border.width: 1
-        border.color: color
     }
 }

--- a/src/StatusQ/Controls/StatusSwitchTabBar.qml
+++ b/src/StatusQ/Controls/StatusSwitchTabBar.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import StatusQ.Core.Theme 0.1
+
+TabBar {
+    id: control
+    padding: 1
+
+    background: Rectangle {
+        implicitHeight: 36
+        color: Theme.palette.directColor7
+        radius: 8
+        border.width: 1
+        border.color: color
+    }
+}

--- a/src/StatusQ/Controls/StatusSwitchTabButton.qml
+++ b/src/StatusQ/Controls/StatusSwitchTabButton.qml
@@ -6,19 +6,22 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 TabButton {
-    id: control
+    id: statusSwitchTabButton
+
     contentItem: Item {
         height: 36
         MouseArea {
             id: sensor
             hoverEnabled: true
             anchors.fill: parent
-            cursorShape: control.hovered ? Qt.PointingHandCursor : Qt.ArrowCursor
-            onClicked: control.checked = true
+
+            cursorShape: Qt.PointingHandCursor
+            onPressed: mouse.accepted = false
+            onReleased: mouse.accepted = false
 
             StatusBaseText {
                 id: label
-                text: control.text
+                text: statusSwitchTabButton.text
                 color: Theme.palette.primaryColor1
                 font.weight: Font.Medium
                 font.pixelSize: 15
@@ -32,16 +35,12 @@ TabButton {
         id: controlBackground
         implicitHeight: 36
         implicitWidth: 148
-        color: control.checked ? 
+        color: statusSwitchTabButton.checked ?
             Theme.palette.statusSwitchTab.backgroundColor :
             "transparent"
         radius: 8
         layer.enabled: true
         layer.effect: DropShadow {
-            width: controlBackground.width
-            height: controlBackground.height
-            x: controlBackground.x
-            source: controlBackground
             horizontalOffset: 0
             verticalOffset: 0
             radius: 10

--- a/src/StatusQ/Controls/qmldir
+++ b/src/StatusQ/Controls/qmldir
@@ -17,3 +17,5 @@ StatusSlider 0.1 StatusSlider.qml
 StatusBaseInput 0.1 StatusBaseInput.qml
 StatusInput 0.1 StatusInput.qml
 StatusPickerButton 0.1 StatusPickerButton.qml
+StatusSwitchTab 0.1 StatusSwitchTab.qml
+StatusSwitchTabBar 0.1 StatusSwitchTabBar.qml

--- a/src/StatusQ/Controls/qmldir
+++ b/src/StatusQ/Controls/qmldir
@@ -17,5 +17,5 @@ StatusSlider 0.1 StatusSlider.qml
 StatusBaseInput 0.1 StatusBaseInput.qml
 StatusInput 0.1 StatusInput.qml
 StatusPickerButton 0.1 StatusPickerButton.qml
-StatusSwitchTab 0.1 StatusSwitchTab.qml
+StatusSwitchTabButton 0.1 StatusSwitchTabButton.qml
 StatusSwitchTabBar 0.1 StatusSwitchTabBar.qml

--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -177,5 +177,9 @@ ThemePalette {
     property QtObject statusChatInput: QtObject {
         property color secondaryBackgroundColor: "#414141"
     }
+
+    property QtObject statusSwitchTab: QtObject {
+        property color backgroundColor: baseColor3
+    }
 }
 

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -175,5 +175,9 @@ ThemePalette {
     property QtObject statusChatInput: QtObject {
         property color secondaryBackgroundColor: "#E2E6E8"
     }
+
+    property QtObject statusSwitchTab: QtObject {
+        property color backgroundColor: white
+    }
 }
 

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -139,6 +139,10 @@ QtObject {
         property color secondaryBackgroundColor
     }
 
+    property QtObject statusSwitchTab: QtObject {
+        property color backgroundColor
+    }
+
     function alphaColor(color, alpha) {
         let actualColor = Qt.darker(color, 1)
         actualColor.a = alpha

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -263,5 +263,7 @@
         <file>src/assets/img/icons/windows_titlebar/maximize.svg</file>
         <file>src/assets/img/icons/windows_titlebar/minimise.svg</file>
         <file>src/assets/img/icons/windows_titlebar/status.svg</file>
+        <file>src/StatusQ/Controls/StatusSwitchTabButton.qml</file>
+        <file>src/StatusQ/Controls/StatusSwitchTabBar.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This commit adds two new components to the StatusQ.Controls module:

- StatusSwitchTabBar
- StatusSwitchTab

Usage:

```qml
StatusSwitchTabBar {

    StatusSwitchTab {
        text: "Tab 1"
    }

    StatusSwitchTab {
        text: "Tab 2"
    }

    StatusSwitchTab {
        text: "Tab 3"
    }
}
```

Closes #365