### PR TITLE
refactor(StatusModal): Remove custom content property

### DIFF
--- a/sandbox/DemoApp.qml
+++ b/sandbox/DemoApp.qml
@@ -752,7 +752,7 @@ Rectangle {
             icon.name: "notification"
         }
 
-        content: StatusBaseText {
+        contentItem: StatusBaseText {
             anchors.centerIn: parent
             text: "Contact request will be shown here"
             font.pixelSize: 15
@@ -781,7 +781,7 @@ Rectangle {
         header.subTitle: "Public Community"
         header.image.source: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
 
-        content: Column {
+        contentItem: Column {
             width: demoCommunityDetailModal.width
 
             StatusModalDivider {

--- a/sandbox/Popups.qml
+++ b/sandbox/Popups.qml
@@ -145,7 +145,7 @@ Column {
             }
         ]
 
-        content: StatusBaseText {
+        contentItem: StatusBaseText {
             anchors.centerIn: parent
             text: "Some text content"
             font.pixelSize: 15
@@ -169,7 +169,7 @@ Column {
         header.title: "Header"
         header.subTitle: "SubTitle"
 
-        content: StatusBaseText {
+        contentItem: StatusBaseText {
             id: text
             anchors.centerIn: parent
             text: "Some text content"
@@ -181,7 +181,7 @@ Column {
             StatusButton {
                 text: "Change text"
                 onClicked: {
-                    modalWithContentAccess.contentComponent.text = "Changed!"
+                    modalWithContentAccess.contentItem.text = "Changed!"
                 }
             }
         ]
@@ -195,8 +195,7 @@ Column {
         header.icon.isLetterIdenticon: true
         header.icon.background.color: "red"
 
-        content: StatusBaseText {
-            id: text
+        contentItem: StatusBaseText {
             anchors.centerIn: parent
             text: "Some text content"
             font.pixelSize: 15
@@ -207,7 +206,7 @@ Column {
             StatusButton {
                 text: "Change text"
                 onClicked: {
-                    modalWithContentAccess.contentComponent.text = "Changed!"
+                    modalWithLetterIdenticon.contentItem.text = "Changed!"
                 }
             }
         ]
@@ -222,8 +221,7 @@ Column {
 CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
         header.image.isIdenticon: true
 
-        content: StatusBaseText {
-            id: text
+        contentItem: StatusBaseText {
             anchors.centerIn: parent
             text: "Some text content"
             font.pixelSize: 15
@@ -234,7 +232,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             StatusButton {
                 text: "Change text"
                 onClicked: {
-                    modalWithContentAccess.contentComponent.text = "Changed!"
+                    modalWithIdenticon.contentItem.text = "Changed!"
                 }
             }
         ]
@@ -249,8 +247,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
 CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
         header.image.isIdenticon: true
 
-        content: StatusBaseText {
-            id: text
+        contentItem: StatusBaseText {
             anchors.centerIn: parent
             text: "Some text content"
             font.pixelSize: 15
@@ -261,7 +258,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             StatusButton {
                 text: "Change text"
                 onClicked: {
-                    modalWithContentAccess.contentComponent.text = "Changed!"
+                    modalWithLongTitles.contentItem.text = "Changed!"
                 }
             }
         ]

--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -11,12 +11,9 @@ import "statusModal" as Spares
 QC.Popup {
     id: statusModal
 
-    property Component content
-
     property alias headerActionButton: headerImpl.actionButton
 
     property StatusModalHeaderSettings header: StatusModalHeaderSettings {}
-    property alias contentComponent: contentLoader.item
     property alias rightButtons: footerImpl.rightButtons
     property alias leftButtons: footerImpl.leftButtons
     property bool showHeader: true
@@ -27,10 +24,12 @@ QC.Popup {
     parent: QC.Overlay.overlay
 
     width: 480
-    height: contentItem.implicitHeight
+    implicitHeight: contentItem.implicitHeight + headerImpl.implicitHeight + footerImpl.implicitHeight
 
-    margins: 0
-    padding: 0
+    topPadding: headerImpl.implicitHeight
+    bottomPadding: footerImpl.implicitHeight
+    leftPadding: 0
+    rightPadding: 0
 
     modal: true
 
@@ -42,12 +41,10 @@ QC.Popup {
     background: Rectangle {
         color: Theme.palette.statusModal.backgroundColor
         radius: 8
-    }
 
-    contentItem: Column {
-        width: parent.width
         Spares.StatusModalHeader {
             id: headerImpl
+            anchors.top: parent.top
             width: visible ? parent.width : 0
 
             visible: statusModal.showHeader
@@ -60,15 +57,9 @@ QC.Popup {
             onClose: statusModal.close()
         }
 
-        Loader {
-            id: contentLoader
-            width: parent.width
-            active: true
-            sourceComponent: statusModal.content
-        }
-
         Spares.StatusModalFooter {
             id: footerImpl
+            anchors.bottom: parent.bottom
             width: visible ? parent.width : 0
             visible: statusModal.showFooter
         }

--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -17,7 +17,7 @@ StatusModal {
     showHeader: false
     showFooter: false
 
-    property string searchText: contentComponent.searchText
+    property string searchText: contentItem.searchText
     property string noResultsLabel: "No results"
     property string defaultSearchLocationText: "Anywhere"
     property bool loading
@@ -47,7 +47,7 @@ StatusModal {
         setSearchSelection(defaultSearchLocationText, "", "", false, "", "transparent")
     }
 
-    content: Item {
+    contentItem: Item {
         width: parent.width
         height: root.height
         property alias searchText: inputText.text
@@ -343,6 +343,6 @@ StatusModal {
     onClosed: {
         root.resetSearchSelection();
         root.loading = false;
-        contentComponent.searchText = "";
+        contentItem.searchText = "";
     }
 }


### PR DESCRIPTION
BREAKING CHANGES:
- `content` property removed
- `Loader` inside StatusModal removed
- default `contentItem` property should be used now

Closes: #306