### PR TITLE
feat(StatusBaseInput): add keyReleased signal

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -52,6 +52,8 @@ Item {
         name: ""
     }
 
+    signal keyReleased()
+
     implicitWidth: 448
     implicitHeight: multiline ? Math.max(edit.implicitHeight + topPadding + bottomPadding, 44) : 44
 
@@ -160,6 +162,10 @@ Item {
                     } else {
                         event.accepted = true
                     }
+                }
+
+                Keys.onReleased: {
+                    statusBaseInput.keyReleased();
                 }
 
                 onTextChanged: {


### PR DESCRIPTION
This is so that we can get notified when keys on the text edit were released.
Unfortunately we don't seem to be able to attach to `Keys.onReleased` from outside
of the component.

Closes #372