### PR TITLE
feat(StatusBaseInput): introduce focussed property

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -26,6 +26,7 @@ Item {
 
     property alias color: edit.color
     property alias font: edit.font
+    property alias focussed: edit.activeFocus
     property alias verticalAlignmet: edit.verticalAlignment
     property alias horizontalAlignment: edit.horizontalAlignment
 


### PR DESCRIPTION
We can't alias the property as `focus` because this is a final readonly
property, so we're introducing a `focussed` property instead.

Closes #373