### PR TITLE
fix(StatusModal): Remove self-calculating height

### DIFF
--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -24,7 +24,6 @@ QC.Popup {
     parent: QC.Overlay.overlay
 
     width: 480
-    implicitHeight: contentItem.implicitHeight + headerImpl.implicitHeight + footerImpl.implicitHeight
 
     topPadding: headerImpl.implicitHeight
     bottomPadding: footerImpl.implicitHeight


### PR DESCRIPTION
Based on Qt docs `contentItem` must have `implicit` sizes.
link to rules: https://doc.qt.io/qt-5/qml-qtquick-controls2-popup.html#popup-sizing