### PR TITLE
feat(StatusInput) exposed edit component

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -22,6 +22,7 @@ Item {
     property alias selectionEnd: edit.selectionEnd
     property alias cursorPosition: edit.cursorPosition
 
+    property alias edit: edit
     property alias text: edit.text
 
     property alias color: edit.color


### PR DESCRIPTION
We need to be able to call forceActiveFocus, so
TextEdit component should be somehow accessible

Relates to desktop #3310