### PR TITLE
fix(StatusChatListAndCategories): rely on correct tooltip settings prop

### DIFF
--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -129,8 +129,8 @@ Item {
                             }
                         }
 
-                        addButton.tooltip: statusChatListAndCategories.addButtonToolTip
-                        menuButton.tooltip: statusChatListAndCategories.menuButtonToolTip
+                        addButton.tooltip: statusChatListAndCategories.categoryAddButtonToolTip
+                        menuButton.tooltip: statusChatListAndCategories.categoryMenuButtonToolTip
 
                         originalOrder: model.position
                         categoryId: model.categoryId


### PR DESCRIPTION
Category tooltip settings were broken in this component due to a mismatching
property name.

This commit fixes it.