### PR TITLE
fix(StatusAppThreePanelLayout): Fix margin between left and center panels

### DIFF
--- a/src/StatusQ/Layout/StatusAppThreePanelLayout.qml
+++ b/src/StatusQ/Layout/StatusAppThreePanelLayout.qml
@@ -29,6 +29,7 @@ SplitView {
         SplitView.minimumWidth: 300
         SplitView.fillWidth: true
         SplitView.fillHeight: true
+        leftPadding: -5
         contentItem: (!!centerPanel) ? centerPanel : null
         background: Rectangle {
             anchors.fill: parent


### PR DESCRIPTION
This margin shows because of `handle` width incuded in `SplitView` width. Handle have `Component` type and can't accessable for getting sizes. I add `magic constant` as hotfix.

Closes: #307