### PR TITLE
feat(StatusSearchPopup): introduce forceActiveFocus API

### DIFF
--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -51,10 +51,19 @@ StatusModal {
         setSearchSelection(defaultSearchLocationText, "", "", false, "", "transparent")
     }
 
+    function forceActiveFocus() {
+        contentItem.searchInput.forceActiveFocus()
+    }
+
+    onOpened: {
+        forceActiveFocus();
+    }
+
     contentItem: Item {
         width: parent.width
         height: root.height
         property alias searchText: inputText.text
+        property alias searchInput: inputText
 
         ColumnLayout {
             id: contentItemColumn


### PR DESCRIPTION
This is used to enforce focus on the search input when the popup
is opened. In fact users decide to override the search popup's
`onOpened` handler, they still get access to this API to make use of it.