### PR TITLE
feat: update validation for StatusInput and StatusValidator

### DIFF
--- a/sandbox/StatusInputPage.qml
+++ b/sandbox/StatusInputPage.qml
@@ -89,14 +89,15 @@ Column {
         input.placeholderText: "Input with validator"
 
         validators: [
-            StatusMinLengthValidator { minLength: 10 }
-        ]
-
-        onTextChanged: {
-            if (errors && errors.minLength) {
-                errorMessage = `Value can't be shorter than ${errors.minLength.min} but got ${errors.minLength.actual}`
+            StatusMinLengthValidator {
+                minLength: 10
+                error: {
+                    if (errors && errors.minLength) {
+                        errorMessage = `Value can't be shorter than ${errors.minLength.min} but got ${errors.minLength.actual}`
+                    }
+                }
             }
-        }
+        ]
     }
 
     StatusInput {

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -30,7 +30,6 @@ Item {
     property int charLimit: 0
     property string errorMessage: ""
     property list<StatusValidator> validators
-    property bool dirty: false
     property int validationMode: StatusInput.ValidationMode.OnlyWhenDirty
     enum ValidationMode {
         OnlyWhenDirty, // validates input only after it has become dirty
@@ -40,7 +39,7 @@ Item {
     property var errors: ({})
 
     function validate() {
-        if (!dirty && validationMode === StatusInput.ValidationMode.OnlyWhenDirty) {
+        if (!statusBaseInput.dirty && validationMode === StatusInput.ValidationMode.OnlyWhenDirty) {
             return
         }
         statusBaseInput.valid = true
@@ -128,10 +127,7 @@ Item {
         anchors.leftMargin: 16
         anchors.rightMargin: 16
         maximumLength: root.charLimit
-        onTextChanged: {
-            root.dirty = true
-            root.validate()
-        }
+        onTextChanged: root.validate()
 
         Keys.forwardTo: [root]
     }

--- a/src/StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml
@@ -1,0 +1,15 @@
+import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1
+
+StatusValidator {
+    name: "addressOrEns"
+
+    errorMessage: "Please enter a valid address or ENS name"
+
+    validate: function (t) {
+        return Utils.isValidAddress(t) || Utils.isValidEns(t) ?
+            true :
+            { actual: t }
+    }
+}
+

--- a/src/StatusQ/Controls/Validators/StatusAddressValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusAddressValidator.qml
@@ -1,0 +1,15 @@
+import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1
+
+StatusValidator {
+    name: "address"
+
+    error: qsTr("Please enter a valid address")
+
+    validate: function (t) {
+        // TODO: Add ENS name resolution and validation a la
+        // `ui/shared/AddressInput.qml`
+        return Utils.isValidAddress(t) ? true : { actual: t }
+    }
+}
+

--- a/src/StatusQ/Controls/Validators/StatusAddressValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusAddressValidator.qml
@@ -4,7 +4,7 @@ import StatusQ.Core.Utils 0.1
 StatusValidator {
     name: "address"
 
-    error: qsTr("Please enter a valid address")
+    errorMessage: "Please enter a valid address"
 
     validate: function (t) {
         // TODO: Add ENS name resolution and validation a la

--- a/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
@@ -3,14 +3,13 @@ import StatusQ.Controls 0.1
 StatusValidator {
 
     property int minLength: 0
-    property string fieldName: "value"
 
     name: "minLength"
 
-    error: {
+    errorMessage: {
         minLength === 1 ?
-            qsTr("You need to enter a %1").arg(fieldName) :
-            qsTr("Value has to be at least %1 characters long").arg(minLength)
+            "Please enter a value" :
+            `Value is ${errors.address.actual} characters, but must be at least ${minLength}.`
     }
 
     validate: function (value) {

--- a/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusMinLengthValidator.qml
@@ -3,8 +3,15 @@ import StatusQ.Controls 0.1
 StatusValidator {
 
     property int minLength: 0
+    property string fieldName: "value"
 
     name: "minLength"
+
+    error: {
+        minLength === 1 ?
+            qsTr("You need to enter a %1").arg(fieldName) :
+            qsTr("Value has to be at least %1 characters long").arg(minLength)
+    }
 
     validate: function (value) {
         return value.length >= minLength ? true : {

--- a/src/StatusQ/Controls/Validators/StatusValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusValidator.qml
@@ -4,7 +4,7 @@ QtObject {
     id: statusValidator
 
     property string name: ""
-    property string error: "invalid input"
+    property string errorMessage: "invalid input"
 
     property var validate: function (value) {
         return true

--- a/src/StatusQ/Controls/Validators/StatusValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusValidator.qml
@@ -4,6 +4,7 @@ QtObject {
     id: statusValidator
 
     property string name: ""
+    property string error: "invalid input"
 
     property var validate: function (value) {
         return true

--- a/src/StatusQ/Controls/Validators/qmldir
+++ b/src/StatusQ/Controls/Validators/qmldir
@@ -1,6 +1,7 @@
 module StatusQ.Controls.Validators
 
 StatusAddressValidator 0.1 StatusAddressValidator.qml
+StatusAddressOrEnsValidator 0.1 StatusAddressValidator.qml
 StatusValidator 0.1 StatusValidator.qml
 StatusMinLengthValidator 0.1 StatusMinLengthValidator.qml
 StatusMaxLengthValidator 0.1 StatusMaxLengthValidator.qml

--- a/src/StatusQ/Controls/Validators/qmldir
+++ b/src/StatusQ/Controls/Validators/qmldir
@@ -1,5 +1,6 @@
 module StatusQ.Controls.Validators
 
+StatusAddressValidator 0.1 StatusAddressValidator.qml
 StatusValidator 0.1 StatusValidator.qml
 StatusMinLengthValidator 0.1 StatusMinLengthValidator.qml
 StatusMaxLengthValidator 0.1 StatusMaxLengthValidator.qml

--- a/src/StatusQ/Core/Utils/Utils.qml
+++ b/src/StatusQ/Core/Utils/Utils.qml
@@ -14,6 +14,9 @@ QtObject {
         }
         return returnPos;
     }
+    function isValidAddress(inputValue) {
+        return inputValue !== "0x" && /^0x[a-fA-F0-9]{40}$/.test(inputValue)
+    }
 }
 
 

--- a/src/StatusQ/Core/Utils/Utils.qml
+++ b/src/StatusQ/Core/Utils/Utils.qml
@@ -17,6 +17,15 @@ QtObject {
     function isValidAddress(inputValue) {
         return inputValue !== "0x" && /^0x[a-fA-F0-9]{40}$/.test(inputValue)
     }
+
+    function isValidEns(inputValue) {
+        if (!inputValue) {
+            return false
+        }
+        const isEmail = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/.test(inputValue)
+        const isDomain = /(?:(?:(?<thld>[\w\-]*)(?:\.))?(?<sld>[\w\-]*))\.(?<tld>[\w\-]*)/.test(inputValue)
+        return isEmail || isDomain || (inputValue.startsWith("@") && inputValue.length > 1)
+    }
 }
 
 


### PR DESCRIPTION
`StatusInput` can now support multiple validators.

`StatusValidators` can now specify an error message directly in the validator component, which will appear when invalid.

`StatusInput` now has a validation mode that allows it to be validated when dirty, or always (regardless of dirty).