### PR TITLE
feat(StatusInput): add support for asynchronous validators

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -47,6 +47,7 @@ Item {
     property bool valid: true
     property bool pristine: true
     property bool dirty: false
+    property bool pending: false
     property bool leftIcon: true
 
     property StatusIconSettings icon: StatusIconSettings {

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -29,6 +29,8 @@ Item {
     property string secondaryLabel: ""
     property int charLimit: 0
     property string errorMessage: ""
+    property real leftPadding: 16
+    property real rightPadding: 16
     property list<StatusValidator> validators
     property int validationMode: StatusInput.ValidationMode.OnlyWhenDirty
     enum ValidationMode {
@@ -85,9 +87,9 @@ Item {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: visible ? 8 : 0
-        anchors.leftMargin: 16
+        anchors.leftMargin: root.leftPadding
         anchors.right: (charLimitLabel.visible ? charLimitLabel.right : parent.right)
-        anchors.rightMargin: 16
+        anchors.rightMargin: root.rightPadding
         height: visible ? 17 : 0
         visible: !!root.label
         spacing: 5
@@ -116,7 +118,7 @@ Item {
         anchors.top: parent.top
         anchors.right: parent.right
         anchors.topMargin: visible ? 11 : 0
-        anchors.rightMargin: 16
+        anchors.rightMargin: root.rightPadding
         visible: root.charLimit > 0
 
         text: "%1 / %2".arg(statusBaseInput.text.length).arg(root.charLimit)
@@ -131,8 +133,8 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.topMargin: charLimitLabel.visible ? 11 : 8
-        anchors.leftMargin: 16
-        anchors.rightMargin: 16
+        anchors.leftMargin: root.leftPadding
+        anchors.rightMargin: root.rightPadding
         maximumLength: root.charLimit
         onTextChanged: root.validate()
 
@@ -145,9 +147,9 @@ Item {
         anchors.top: statusBaseInput.bottom
         anchors.topMargin: 11
         anchors.right: parent.right
-        anchors.rightMargin: 16
+        anchors.rightMargin: root.rightPadding
         anchors.left: parent.left
-        anchors.leftMargin: 16
+        anchors.leftMargin: root.leftPadding
 
         height: visible ? implicitHeight : 0
         visible: !!text && !statusBaseInput.valid

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -38,6 +38,13 @@ Item {
 
     property var errors: ({})
 
+    function reset() {
+        statusBaseInput.valid = false
+        statusBaseInput.pristine = true
+        statusBaseInput.text = ""
+        errorMessage = ""
+    }
+
     function validate() {
         if (!statusBaseInput.dirty && validationMode === StatusInput.ValidationMode.OnlyWhenDirty) {
             return

--- a/src/StatusQ/Controls/Validators/StatusValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusValidator.qml
@@ -1,10 +1,12 @@
 import QtQuick 2.13
+import StatusQ.Controls 0.1
 
 QtObject {
     id: statusValidator
 
     property string name: ""
     property string errorMessage: "invalid input"
+    property StatusInput input
 
     property var validate: function (value) {
         return true


### PR DESCRIPTION
This adds support for asynchronous validators which are also just `StatusValidator`.

There are a few differences to syncronous validators though:

1. `validate` function doesn't return, it's only used to trigger the async
   validation. Ideally it would return an async object like Promise or Observable
   but since we have to rely on QML `Connections`, this won't work.
2. As mentioned, `Connections` are needed to listen to async events so the
  validation can be resolved.
3. Validation has to be resolved by calling `input.updateValidity` inside the validator.
   That API notifies `StatusInput` that validation is has been performed and expects
   the name of the validator as well as either a boolean (true), if validation was successful,
   or, if validation has failed, a boolean (false) or an error object.

Here's a `StatusENSValidator` as an example:

```qml
StatusValidator {

    id: root

    name: "ensValidator"
    errorMessage: "Couldn't resolve ENS name."

    readonly property string uuid: Utils.uuid()

    property int debounceTime: 600

    signal ensResolved(string address)

    validate: Backpressure.debounce(root, root.debounceTime, function (name) {
        name = name.startsWith("@") ? name.substring(1) : name
        walletModel.ensView.resolveENS(name, uuid)
    })

    Connections {
        target: walletModel.ensView
        onEnsWasResolved: {
            if (uuid !== root.uuid) {
                return
            }
            root.ensResolved(resolvedAddress)
            input.updateValidityAndPendingState(root.name, resolvedAddress !== "")
        }
    }
}
```

Closes #395