### PR TITLE
fix(StatusListItem) Disable sensor when chevron clicked

### DIFF
--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -42,14 +42,15 @@ Column {
 
         highlighted: statusChatListCategory.dragged
         sensor.onClicked: {
-            if (mouse.button === Qt.RightButton && showActionButtons && !!statusChatListCategory.popupMenu) {
-                highlighted = true
-                popupMenuSlot.item.popup(mouse.x + 4, mouse.y + 6)
-                return
+            if (sensor.enabled) {
+                if (mouse.button === Qt.RightButton && showActionButtons && !!statusChatListCategory.popupMenu) {
+                    highlighted = true;
+                    popupMenuSlot.item.popup(mouse.x + 4, mouse.y + 6);
+                    return
+                }
+                statusChatListCategory.opened = !opened;
             }
-            statusChatListCategory.opened = !opened
         }
-
         onTitleClicked: statusChatListCategory.opened = !opened
         onToggleButtonClicked: statusChatListCategory.opened = !opened
         onMenuButtonClicked: {

--- a/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -60,7 +60,15 @@ StatusListItem {
             icon.name: "chevron-down"
             icon.width: 18
             icon.rotation: statusChatListCategoryItem.opened ? 0 : 270
-            onClicked: statusChatListCategoryItem.toggleButtonClicked(mouse)
+            onPressed: {
+                sensor.enabled = false;
+            }
+            onClicked: {
+                statusChatListCategoryItem.toggleButtonClicked(mouse);
+            }
+            onReleased: {
+                sensor.enabled = true;
+            }
         }
     ]
 }

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -51,7 +51,7 @@ Rectangle {
         width: 20
         rotation: 0
         isLetterIdenticon: false
-        color: type === StatusListItem.Type.Danger ? 
+        color: type === StatusListItem.Type.Danger ?
             Theme.palette.dangerColor1 : Theme.palette.primaryColor1
         background: StatusIconBackgroundSettings {
             width: 40
@@ -60,11 +60,11 @@ Rectangle {
                 if (sensor.containsMouse) {
                     return type === StatusListItem.Type.Secondary ||
                            type === StatusListItem.Type.Danger ? "transparent" :
-                           Theme.palette.primaryColor3     
+                           Theme.palette.primaryColor3
                 }
-                return type === StatusListItem.Type.Danger ? 
+                return type === StatusListItem.Type.Danger ?
                     Theme.palette.dangerColor3 : Theme.palette.primaryColor3
-            }        
+            }
         }
     }
     property StatusImageSettings image: StatusImageSettings {
@@ -123,8 +123,8 @@ Rectangle {
                 return !!statusListItem.icon.name ? statusRoundedIcon : statusRoundedImage
             }
 
-            active: statusListItem.icon.isLetterIdenticon || 
-                    !!statusListItem.icon.name || 
+            active: statusListItem.icon.isLetterIdenticon ||
+                    !!statusListItem.icon.name ||
                     !!statusListItem.image.source.toString()
         }
 


### PR DESCRIPTION
List items' mouse area was also triggered when chevron (sub menu) button was clicked so it was unsetting the opened variable which is responsible for opening/closing the chats list.

Relates to https://github.com/status-im/status-desktop/issues/3484