### PR TITLE
feat(StatusChatList): expose `statusChatListItems` Repeater

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -19,6 +19,8 @@ Column {
     property alias chatListItems: delegateModel
     property bool draggableItems: false
 
+    property alias statusChatListItems: statusChatListItems
+
     property Component popupMenu
 
     property var filterFn


### PR DESCRIPTION
Ever since we've moved to `DelegateModel` which is passed to the `Repeater`
which was previously aliased as `chatListItems`, we no longer get access to the
`model.itemAt` method. This is because `DelegateModel` doesn't have such a method.

So in order to restore that access, we have to expose `Repeater` additionally.

The reason this method is needed, is so that apps like Status Desktop can update
individual chat list items based on `Connection` events