### PR TITLE
fix: track category opened state

### DIFF
--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -28,6 +28,9 @@ Item {
     property alias sensor: sensor
     property bool draggableItems: false
     property bool draggableCategories: false
+    // Keeps track of expanded category state. Should only be modified
+    // internally at runtime.
+    property var openedCategoryState: new Object({})
 
     property Component categoryPopupMenu
     property Component chatListPopupMenu
@@ -147,6 +150,21 @@ Item {
 
                         popupMenu: statusChatListAndCategories.categoryPopupMenu
                         chatListPopupMenu: statusChatListAndCategories.chatListPopupMenu
+
+                        // Used to set the initial value of "opened" when the
+                        // model is bound/changed.
+                        opened: {
+                            let openedState = statusChatListAndCategories.openedCategoryState[model.categoryId]
+                            return openedState !== undefined ? openedState : true // defaults to open
+                        }
+
+                        // Used to track the internal changes of the `opened`
+                        // property. This cannot be brought inside the component
+                        // as the state would be lost each time the model is
+                        // changed.
+                        onOpenedChanged: {
+                            statusChatListAndCategories.openedCategoryState[model.categoryId] = statusChatListCategory.opened
+                        }
                     }
 
                     DropArea {


### PR DESCRIPTION
Category `opened` state is tracked and restored on model change.

Previously, when the model data for categories and channels was changed, all unexpanded, or collapsed categories would automatically expand. This was due to the default state of the category `opened` property being restored (which was set to true) when the model data changed.

With this change in place, the opened state of each category is tracked in the parent component (`StatusChatListAndCategories`), and on each model change, the opened state is restored.

NOTE: it was tempting to the put the changes inside of the `StatusChatListCategory` component, however this would not work as the component is used as a delegate, and all state is wiped on each model change.