### PR TITLE
WIP: implement cross category drag and drop

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -18,7 +18,7 @@ Column {
 
     property string categoryId: ""
     property string selectedChatId: ""
-    property alias chatListItems: delegateModel
+    property alias chatListItems: statusChatListItems
     property bool draggableItems: false
 
     property alias statusChatListItems: statusChatListItems
@@ -39,245 +39,254 @@ Column {
         }
     }
 
-    DelegateModel {
-        id: delegateModel
+    Column {
+        id: statusChatListItemsWrapper
+        width: parent.width
+        spacing: 4
+        onImplicitHeightChanged: {
+            // For some reason, the binding on emptyListDropAreaLoaoder.active alone doesn't work.
+            // We have to explicitly reassign it here.
+            emptyListDropAreaLoader.active = implicitHeight == 0            
+        }
 
-        delegate: Item {
-            id: draggable
-            width: statusChatListItem.width
-            /* height: dragSensor.active ? 0 : statusChatListItem.height + 4 */
-            height: {
-                if (dropArea.containsDrag) {
-                    if (dropArea.drag.source.chatListItem.chatId == statusChatListItem.chatId) {
-                        return statusChatListItem.height + 4
+        Repeater {
+            id: statusChatListItems
+            delegate: Item {
+                id: draggable
+                width: statusChatListItem.width
+                height: statusChatListItem.height
+
+                property alias chatListItem: statusChatListItem
+
+                visible: {
+                    if (!!statusChatList.filterFn) {
+                        return statusChatList.filterFn(model, statusChatList.categoryId)
                     }
-                    return (statusChatListItem.height + 4 ) * 2
-                } else {
-                    return statusChatListItem.height + 4
-                }
-            }
-
-            property alias chatListItem: statusChatListItem
-
-            visible: {
-                if (!!statusChatList.filterFn) {
-                    return statusChatList.filterFn(model, statusChatList.categoryId)
-                }
-                return true
-            }
-
-            MouseArea {
-                id: dragSensor
-
-                anchors.topMargin: 2
-                anchors.bottomMargin: 2
-                anchors.top: parent.top
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                cursorShape: active ? Qt.ClosedHandCursor : Qt.PointingHandCursor
-                hoverEnabled: true
-                pressAndHoldInterval: 150
-                enabled: statusChatList.draggableItems
-
-                property bool active: false
-                property real startY: 0
-                property real startX: 0
-
-                drag.target: draggedListItemLoader.item
-                drag.threshold: 0.1
-                drag.filterChildren: true
-
-                onPressed: {
-                    startY = mouseY
-                    startX = mouseX
+                    return true
                 }
 
-                onActiveChanged: {
-                    if (!active) {
-                        draggable.height = statusChatListItem.height + 4
+                MouseArea {
+                    id: dragSensor
+
+                    anchors.fill: parent
+                    cursorShape: active ? Qt.ClosedHandCursor : Qt.PointingHandCursor
+                    hoverEnabled: true
+                    pressAndHoldInterval: 150
+                    enabled: statusChatList.draggableItems
+
+                    property bool active: false
+                    property real startY: 0
+                    property real startX: 0
+
+                    drag.target: draggedListItemLoader.item
+                    drag.threshold: 0.1
+                    drag.filterChildren: true
+
+                    onPressed: {
+                        startY = mouseY
+                        startX = mouseX
                     }
-                }
-                onPressAndHold: active = true
-                onReleased: {
-                    if (active) {
-                        statusChatList.chatItemReordered(statusChatListItem.newCategoryId, statusChatListItem.chatId, statusChatListItem.originalOrder, statusChatListItem.newOrder)
-                    }
-                    active = false
-                    /* console.log("RELEASING! ", statusChatListItem.originalOrder, draggedListItemLoader.item.newPosition) */
-                }
-                onMouseYChanged: {
-                    if ((Math.abs(startY - mouseY) > 1) && pressed) {
-                        active = true
-                    }
-                }
-                onMouseXChanged: {
-                    if ((Math.abs(startX - mouseX) > 1) && pressed) {
-                        active = true
-                    }
-                }
 
-                StatusChatListItem {
-
-                    id: statusChatListItem
-
-                    property string chatListId: statusChatList.uuid
-                    property string profileImage: ""
-                    property var newOrder: model.position
-                    property var newCategoryId: model.categoryId
-
-                    anchors.centerIn: parent
-                    /* anchors.horizontalCenter: parent.horizontalCenter */
-                    anchors.verticalCenterOffset: {
-                        if (dropArea.containsDrag) {
-                            return dropArea.drag.y <= dropArea.height/2 ? 
-                                  (statusChatListItem.height+4) / 2 : 
-                                  -(statusChatListItem.height+4) / 2
+                    onPressAndHold: active = true
+                    onReleased: {
+                        if (active && (statusChatListItem.originalOder !== statusChatListItem.newOrder || 
+                             statusChatListItem.categoryId !== statusChatListItem.newCategoryId)) {
+                            statusChatList.chatItemReordered(
+                              statusChatListItem.newCategoryId, 
+                              statusChatListItem.chatId, 
+                              statusChatListItem.originalOrder, 
+                              statusChatListItem.newOrder
+                            )
                         }
-                        return 0
+                        active = false
                     }
-                    /* Behavior on anchors.verticalCenterOffset { */
-                    /*     enabled: dropArea.containsDrag */
-                    /*     NumberAnimation { duration: 100 } */
-                    /* } */
-                    opacity: dragSensor.active ? 0.0 : 1.0
-                    Component.onCompleted: {
-                        if (typeof statusChatList.profileImageFn === "function") {
-                            profileImage = statusChatList.profileImageFn(model.chatId || model.id) || ""
+                    onMouseYChanged: {
+                        if ((Math.abs(startY - mouseY) > 1) && pressed) {
+                            active = true
                         }
                     }
-                    originalOrder: model.position
-                    chatId: model.chatId || model.id
-                    categoryId: model.categoryId || ""
-                    name: (!!statusChatList.chatNameFn ? statusChatList.chatNameFn(model) : model.name) + " POSITION: " + statusChatListItem.newOrder
-                    type: model.chatType
-                    muted: !!model.muted
-                    hasUnreadMessages: !!model.hasUnreadMessages || model.unviewedMessagesCount > 0
-                    hasMention: model.mentionsCount > 0
-                    badge.value: model.chatType === StatusChatListItem.Type.OneToOneChat ?
-                        model.unviewedMessagesCount || 0 :
-                        model.mentionsCount || 0
-                    selected: (model.chatId || model.id) === statusChatList.selectedChatId
+                    onMouseXChanged: {
+                        if ((Math.abs(startX - mouseX) > 1) && pressed) {
+                            active = true
+                        }
+                    }
 
-                    icon.color: model.color || ""
-                    image.isIdenticon: !!!profileImage && !!!model.identityImage && !!model.identicon
-                    image.source: profileImage || model.identityImage || model.identicon || ""
+                    StatusChatListItem {
 
-                    sensor.cursorShape: dragSensor.cursorShape
-                    onClicked: {
-                        if (mouse.button === Qt.RightButton && !!statusChatList.popupMenu) {
-                            statusChatListItem.highlighted = true
+                        id: statusChatListItem
 
-                            let originalOpenHandler = popupMenuSlot.item.openHandler
-                            let originalCloseHandler = popupMenuSlot.item.closeHandler
+                        property string chatListId: statusChatList.uuid
+                        property string profileImage: ""
+                        property var newOrder: model.position
+                        property var newCategoryId: model.categoryId
 
-                            popupMenuSlot.item.openHandler = function () {
-                                if (!!originalOpenHandler) {
-                                    originalOpenHandler((model.chatId || model.id))
-                                }
+                        anchors.centerIn: parent
+                        opacity: dragSensor.active ? 0.3 : 1.0
+                        Component.onCompleted: {
+                            if (typeof statusChatList.profileImageFn === "function") {
+                                profileImage = statusChatList.profileImageFn(model.chatId || model.id) || ""
                             }
-
-                            popupMenuSlot.item.closeHandler = function () {
-                                if (statusChatListItem) {
-                                    statusChatListItem.highlighted = false
-                                }
-                                if (!!originalCloseHandler) {
-                                    originalCloseHandler()
-                                }
-                            }
-
-                            popupMenuSlot.item.popup(mouse.x + 4, statusChatListItem.y + mouse.y + 6)
-                            popupMenuSlot.item.openHandler = originalOpenHandler
-                            return
                         }
-                        if (!statusChatListItem.selected) {
-                            statusChatList.chatItemSelected(model.chatId || model.id)
-                        }
-                    }
-                    onUnmute: statusChatList.chatItemUnmuted(model.chatId || model.id)
-                }
-            }
+                        originalOrder: model.position
+                        chatId: model.chatId || model.id
+                        categoryId: model.categoryId || ""
+                        /* name: (!!statusChatList.chatNameFn ? statusChatList.chatNameFn(model) : model.name) + " POSITION: " + statusChatListItem.newOrder */
+                        name: (!!statusChatList.chatNameFn ? statusChatList.chatNameFn(model) : model.name)
+                        type: model.chatType
+                        muted: !!model.muted
+                        hasUnreadMessages: !!model.hasUnreadMessages || model.unviewedMessagesCount > 0
+                        hasMention: model.mentionsCount > 0
+                        badge.value: model.chatType === StatusChatListItem.Type.OneToOneChat ?
+                            model.unviewedMessagesCount || 0 :
+                            model.mentionsCount || 0
+                        selected: (model.chatId || model.id) === statusChatList.selectedChatId
 
-            DropArea {
-                id: dropArea
-                width: parent.width
-                height: parent.height
-                /* keys: ["chat-item-category-" + statusChatListItem.categoryId] */
-                keys: ["chat-item"]
+                        icon.color: model.color || ""
+                        image.isIdenticon: !!!profileImage && !!!model.identityImage && !!model.identicon
+                        image.source: profileImage || model.identityImage || model.identicon || ""
 
-                onEntered: reorderDelay.start()
-                onExited: {
-                    if (drag.source.chatListItem.chatId == statusChatListItem.chatId) {
-                        draggable.height = 0
-                    }
-                }
+                        sensor.cursorShape: dragSensor.cursorShape
+                        onClicked: {
+                            if (mouse.button === Qt.RightButton && !!statusChatList.popupMenu) {
+                                statusChatListItem.highlighted = true
 
-                Timer {
-                    id: reorderDelay
-                    interval: 100
-                    repeat: false
-                    onTriggered: {
-                        if (dropArea.containsDrag) {
-                            let newOrder = statusChatListItem.originalOrder
-                            if (dropArea.drag.source.chatListItem.categoryId !== statusChatListItem.categoryId) {
-                                if (dropArea.drag.y <= dropArea.height/2) {
-                                    if (newOrder > 0) {
-                                        newOrder = newOrder - 1
+                                let originalOpenHandler = popupMenuSlot.item.openHandler
+                                let originalCloseHandler = popupMenuSlot.item.closeHandler
+
+                                popupMenuSlot.item.openHandler = function () {
+                                    if (!!originalOpenHandler) {
+                                        originalOpenHandler((model.chatId || model.id))
                                     }
                                 }
+
+                                popupMenuSlot.item.closeHandler = function () {
+                                    if (statusChatListItem) {
+                                        statusChatListItem.highlighted = false
+                                    }
+                                    if (!!originalCloseHandler) {
+                                        originalCloseHandler()
+                                    }
+                                }
+
+                                popupMenuSlot.item.popup(mouse.x + 4, statusChatListItem.y + mouse.y + 6)
+                                popupMenuSlot.item.openHandler = originalOpenHandler
+                                return
                             }
-                            dropArea.drag.source.chatListItem.newOrder = newOrder
-                            dropArea.drag.source.chatListItem.newCategoryId = statusChatListItem.categoryId
+                            if (!statusChatListItem.selected) {
+                                statusChatList.chatItemSelected(model.chatId || model.id)
+                            }
+                        }
+                        onUnmute: statusChatList.chatItemUnmuted(model.chatId || model.id)
+
+                        StatusChatListDropIndicator {
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: -2
+                            visible: dropArea.containsDrag
                         }
                     }
                 }
-            }
+                DropArea {
+                    id: dropArea
+                    width: parent.width
+                    height: parent.height
+                    keys: ["chat-item"]
 
-            Loader {
-                id: draggedListItemLoader
-                active: dragSensor.active
-                sourceComponent: StatusChatListItem {
-                    property string chatListId: draggable.chatListItem.chatListId
-                    property var globalPosition: Utils.getAbsolutePosition(draggable)
-                    parent: QC.Overlay.overlay
-                    sensor.cursorShape: dragSensor.cursorShape
-                    Drag.active: dragSensor.active
-                    Drag.hotSpot.x: width / 2
-                    Drag.hotSpot.y: height / 2
-                    /* Drag.keys: ["chat-item-category-" + categoryId] */
-                    Drag.keys: ["chat-item"]
-                    Drag.source: draggable
+                    onEntered: reorderDelay.start()
 
-                    Component.onCompleted: {
-                        x = globalPosition.x
-                        y = globalPosition.y
+                    Timer {
+                        id: reorderDelay
+                        interval: 100
+                        repeat: false
+                        onTriggered: {
+                            if (dropArea.containsDrag) {
+                                let newOrder = statusChatListItem.originalOrder
+
+                                if (dropArea.drag.source.chatListItem.originalOrder > statusChatListItem.originalOrder) {
+                                    newOrder = newOrder + 1
+                                }
+                                dropArea.drag.source.chatListItem.newOrder = newOrder
+                                dropArea.drag.source.chatListItem.newCategoryId = statusChatListItem.categoryId
+                            }
+                        }
                     }
-                    chatId: draggable.chatListItem.chatId
-                    categoryId: draggable.chatListItem.categoryId
-                    name: draggable.chatListItem.name
-                    type: draggable.chatListItem.type
-                    muted: draggable.chatListItem.muted
-                    dragged: true
-                    hasUnreadMessages: draggable.chatListItem.hasUnreadMessages
-                    hasMention: draggable.chatListItem.hasMention
-                    badge.value: draggable.chatListItem.badge.value
-                    selected: draggable.chatListItem.selected
+                }
+                Loader {
+                    id: draggedListItemLoader
+                    active: dragSensor.active
+                    sourceComponent: StatusChatListItem {
+                        property string chatListId: draggable.chatListItem.chatListId
+                        property var globalPosition: Utils.getAbsolutePosition(draggable)
+                        parent: QC.Overlay.overlay
+                        sensor.cursorShape: dragSensor.cursorShape
+                        Drag.active: dragSensor.active
+                        Drag.hotSpot.x: width / 2
+                        Drag.hotSpot.y: height / 2
+                        Drag.keys: ["chat-item"]
+                        Drag.source: draggable
 
-                    icon.color: draggable.chatListItem.icon.color
-                    image.isIdenticon: draggable.chatListItem.image.isIdenticon
-                    image.source: draggable.chatListItem.image.source
+                        Component.onCompleted: {
+                            x = globalPosition.x
+                            y = globalPosition.y
+                        }
+                        chatId: draggable.chatListItem.chatId
+                        categoryId: draggable.chatListItem.categoryId
+                        name: draggable.chatListItem.name
+                        type: draggable.chatListItem.type
+                        muted: draggable.chatListItem.muted
+                        dragged: true
+                        hasUnreadMessages: draggable.chatListItem.hasUnreadMessages
+                        hasMention: draggable.chatListItem.hasMention
+                        badge.value: draggable.chatListItem.badge.value
+                        selected: draggable.chatListItem.selected
+
+                        icon.color: draggable.chatListItem.icon.color
+                        image.isIdenticon: draggable.chatListItem.image.isIdenticon
+                        image.source: draggable.chatListItem.image.source
+                    }
                 }
             }
         }
     }
 
-    Repeater {
-        id: statusChatListItems
-        model: delegateModel
-    }
-
     Loader {
         id: popupMenuSlot
         active: !!statusChatList.popupMenu
+    }
+
+    Loader {
+        id: emptyListDropAreaLoader
+        active: statusChatListItemsWrapper.implicitHeight == 0
+        width: parent.width
+        height: active ? 8 : 0
+        sourceComponent: Item {
+            width: statusChatList.width
+            height: 8
+
+            StatusChatListDropIndicator {
+                visible: emptyListDropArea.containsDrag
+                opacity: 0.5
+                anchors.bottom: statusChatList.categoryId == "" ? parent.bottom : undefined
+                anchors.top: statusChatList.categoryId !== "" ? parent.top : undefined
+            }
+
+            DropArea {
+                id: emptyListDropArea
+                anchors.fill: parent
+                visible: parent.visible
+                keys: ["chat-item"]
+                onEntered: reorderDelay2.start()
+                Timer {
+                    id: reorderDelay2
+                    interval: 100
+                    repeat: false
+                    onTriggered: {
+                        if (emptyListDropArea.containsDrag) {
+                            emptyListDropArea.drag.source.chatListItem.newOrder = 0
+                            emptyListDropArea.drag.source.chatListItem.newCategoryId = statusChatList.categoryId
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -100,8 +100,10 @@ Column {
                 }
                 onPressAndHold: active = true
                 onReleased: {
+                    if (active) {
+                        statusChatList.chatItemReordered(statusChatListItem.newCategoryId, statusChatListItem.chatId, statusChatListItem.originalOrder, statusChatListItem.newOrder)
+                    }
                     active = false
-                    statusChatList.chatItemReordered(statusChatListItem.newCategoryId, statusChatListItem.chatId, statusChatListItem.originalOrder, statusChatListItem.newOrder)
                     /* console.log("RELEASING! ", statusChatListItem.originalOrder, draggedListItemLoader.item.newPosition) */
                 }
                 onMouseYChanged: {
@@ -125,6 +127,7 @@ Column {
                     property var newCategoryId: model.categoryId
 
                     anchors.centerIn: parent
+                    /* anchors.horizontalCenter: parent.horizontalCenter */
                     anchors.verticalCenterOffset: {
                         if (dropArea.containsDrag) {
                             return dropArea.drag.y <= dropArea.height/2 ? 
@@ -146,7 +149,7 @@ Column {
                     originalOrder: model.position
                     chatId: model.chatId || model.id
                     categoryId: model.categoryId || ""
-                    name: !!statusChatList.chatNameFn ? statusChatList.chatNameFn(model) : model.name
+                    name: (!!statusChatList.chatNameFn ? statusChatList.chatNameFn(model) : model.name) + " POSITION: " + statusChatListItem.newOrder
                     type: model.chatType
                     muted: !!model.muted
                     hasUnreadMessages: !!model.hasUnreadMessages || model.unviewedMessagesCount > 0
@@ -216,13 +219,13 @@ Column {
                     onTriggered: {
                         if (dropArea.containsDrag) {
                             let newOrder = statusChatListItem.originalOrder
-                            /* if (dropArea.drag.source.chatListItem.categoryId !== statusChatListItem.categoryId) { */
-                            /*     if (dropArea.drag.y <= dropArea.height/2) { */
-                            /*         if (newOrder > 0) { */
-                            /*             newOrder = newOrder - 1 */
-                            /*         } */
-                            /*     } */
-                            /* } */
+                            if (dropArea.drag.source.chatListItem.categoryId !== statusChatListItem.categoryId) {
+                                if (dropArea.drag.y <= dropArea.height/2) {
+                                    if (newOrder > 0) {
+                                        newOrder = newOrder - 1
+                                    }
+                                }
+                            }
                             dropArea.drag.source.chatListItem.newOrder = newOrder
                             dropArea.drag.source.chatListItem.newCategoryId = statusChatListItem.categoryId
                         }

--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -142,7 +142,7 @@ Item {
                         chatList.selectedChatId: statusChatListAndCategories.selectedChatId
                         chatList.onChatItemSelected: statusChatListAndCategories.chatItemSelected(id)
                         chatList.onChatItemUnmuted: statusChatListAndCategories.chatItemUnmuted(id)
-                        chatList.onChatItemReordered: statusChatListAndCategories.chatItemReordered(model.categoryId, id, from, to)
+                        chatList.onChatItemReordered: statusChatListAndCategories.chatItemReordered(categoryId, id, from, to)
                         chatList.draggableItems: statusChatListAndCategories.draggableItems
 
                         popupMenu: statusChatListAndCategories.categoryPopupMenu
@@ -155,7 +155,9 @@ Item {
                         height: draggable.chatListCategory.dragActive ? 0 : parent.height
                         keys: ["chat-category"]
 
-                        onEntered: reorderDelay.start()
+                        onEntered: {
+                            reorderDelay.start()
+                        }
                         onDropped: statusChatListAndCategories.chatListCategoryReordered(statusChatListCategory.categoryId, drag.source.originalOrder, statusChatListCategory.DelegateModel.itemsIndex)
 
                         Timer {
@@ -168,6 +170,13 @@ Item {
                                     delegateModel.items.move(dropArea.drag.source.DelegateModel.itemsIndex, draggable.DelegateModel.itemsIndex)
                                 }
                             }
+                        }
+
+                        Rectangle {
+                            color: "red"
+                            opacity: 0.1
+                            anchors.fill: parent
+                            visible: dropArea.containsDrag
                         }
                     }
 

--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -171,13 +171,6 @@ Item {
                                 }
                             }
                         }
-
-                        Rectangle {
-                            color: "red"
-                            opacity: 0.1
-                            anchors.fill: parent
-                            visible: dropArea.containsDrag
-                        }
                     }
 
                     Loader {

--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -142,7 +142,14 @@ Item {
                         chatList.selectedChatId: statusChatListAndCategories.selectedChatId
                         chatList.onChatItemSelected: statusChatListAndCategories.chatItemSelected(id)
                         chatList.onChatItemUnmuted: statusChatListAndCategories.chatItemUnmuted(id)
-                        chatList.onChatItemReordered: statusChatListAndCategories.chatItemReordered(categoryId, id, from, to)
+                        chatList.onChatItemReordered: {
+                            console.log("REORDERING CHAT ITEM:")
+                            console.log("FROM CATEGORY: ", model.categoryId)
+                            console.log("TO: ", categoryId)
+                            console.log("FROM POSITION: ", from)
+                            console.log("TO POSITION: ", to)
+                            statusChatListAndCategories.chatItemReordered(categoryId, id, from, to)
+                        }
                         chatList.draggableItems: statusChatListAndCategories.draggableItems
 
                         popupMenu: statusChatListAndCategories.categoryPopupMenu

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.13
 
+import StatusQ.Core.Utils 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
 
@@ -8,6 +9,7 @@ Column {
 
     spacing: 0
     opacity: dragged ? 0.5 : 1
+    property string uuid: Utils.uuid()
 
     objectName: "chatListCategory"
     property int originalOrder: -1
@@ -64,6 +66,7 @@ Column {
 
     StatusChatList {
         id: statusChatList
+        uuid: statusChatListCategory.uuid
         anchors.horizontalCenter: parent.horizontalCenter
         visible: statusChatListCategory.opened
         categoryId: statusChatListCategory.categoryId

--- a/src/StatusQ/Components/StatusChatListDropIndicator.qml
+++ b/src/StatusQ/Components/StatusChatListDropIndicator.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.13
+import StatusQ.Core.Theme 0.1
+
+Rectangle {
+    id: root
+    implicitWidth: 288
+    height: 4
+    color: Theme.palette.successColor1
+    radius: 2
+}
+

--- a/src/StatusQ/Components/qmldir
+++ b/src/StatusQ/Components/qmldir
@@ -3,6 +3,7 @@ module StatusQ.Components
 StatusBadge 0.1 StatusBadge.qml
 StatusChatInfoToolBar 0.1 StatusChatInfoToolBar.qml
 StatusChatList 0.1 StatusChatList.qml
+StatusChatListDropIndicator 0.1 StatusChatListDropIndicator.qml
 StatusChatListItem 0.1 StatusChatListItem.qml
 StatusChatListCategory 0.1 StatusChatListCategory.qml
 StatusChatListCategoryItem 0.1 StatusChatListCategoryItem.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -249,6 +249,7 @@
         <file>src/StatusQ/Controls/StatusBaseInput.qml</file>
         <file>src/StatusQ/Controls/StatusChatListCategoryItemButton.qml</file>
         <file>src/StatusQ/Components/StatusChatList.qml</file>
+        <file>src/StatusQ/Components/StatusChatListDropIndicator.qml</file>
         <file>src/StatusQ/Popups/statusModal/StatusImageWithTitle.qml</file>
         <file>src/StatusQ/Popups/statusModal/StatusModalFooter.qml</file>
         <file>src/StatusQ/Popups/statusModal/StatusModalHeader.qml</file>


### PR DESCRIPTION
I think UI wise, this seems to be pretty much done. 

To allow drag and drop into and out of categories we need to switch to a different approach:

1. No more use of `DelegateModel`. The reason `DelegateModel` was used in the first place, was so that the chat list can be easily **visually** updated as the user is dragging an item over the list (using its `.move()` API). Because dragged items could origin from a different category (/chat list), there's no benefit to using `DelegateModel` anymore
2. Removing `DelegateModel` also eliminates the warnings reported in status-im/status-desktop#7572 which was significantly slowing down the rendering performance.
3. Instead of having items slide up and down, we now just add a "drop indicator" between items. This makes the whole implementation easier and more predictable.
4. There's another `DropArea` added to `StatusChatList` which is activated when a chat list is empty. This is needed so users can drag chat items into empty categories or even just out of categories into "uncategorized" lists
5. Dragged elements now keep track of not only their new position but also their original position (previous `orignalOrder` was just assigned the new position. We now have `newOrder` for that. Should probably rename both to `originalPosition` and `newPosition` respectively`).
6. `chatItemReordered` signal no longer just emits the same `categoryId` in which the dragged item resides in, but rather its `newCategoryId`, in case it was dragged into a different category. Status-go is smart enough to recognize that and moves the chat item into the new category accordingly

**What's missing**:

Proper visual state update **after** the drop has happened but **before** the signal was sent to the backend.