### PR TITLE
fix(StatusSearchPopup): use correct theme color for search result text

### DIFF
--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -301,7 +301,7 @@ StatusModal {
                         radius: 0
                         statusListItemSubTitle.height: model.content !== "" ? 20 : 0
                         statusListItemSubTitle.elide: Text.ElideRight
-                        statusListItemSubTitle.color: Theme.palette.black
+                        statusListItemSubTitle.color: Theme.palette.directColor1
                         icon.isLetterIdenticon: (model.image === "")
                         icon.background.color: model.color
                         titleAsideText: root.formatTimestampFn(model.time)


### PR DESCRIPTION
This used `Theme.palette.black` before which doesn't work across differen themes.
`Theme.palette.directColor1` is the correct one to use here.