### PR TITLE
fix(StatusChatList): ensure right click popup opens in correct position

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -145,7 +145,9 @@ Column {
                                 }
                             }
 
-                            popupMenuSlot.item.popup(mouse.x + 4, statusChatListItem.y + mouse.y + 6)
+                            let p = statusChatListItem.mapToItem(statusChatList, mouse.x, mouse.y)
+
+                            popupMenuSlot.item.popup(p.x + 4, p.y + 6)
                             popupMenuSlot.item.openHandler = originalOpenHandler
                             return
                         }


### PR DESCRIPTION
This broke because the emitted `mouse` coordinates where no longer correct
after we've moved the chat list item into a delegate model.