### PR TITLE
fix(StatusInput): ensure validator messages are rendered when validat…

### DIFF
--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -72,6 +72,11 @@ Item {
                     if (!errors) {
                         errors = {}
                     }
+                    if (typeof result === "boolean") {
+                        result = {
+                            valid: result
+                        }
+                    }
                     result.errorMessage = validator.errorMessage
                     errors[validator.name] = result
                     statusBaseInput.valid = statusBaseInput.valid && false


### PR DESCRIPTION
…ors return boolean values

There's two ways to signal that a validator emits invalidity on a control:

1. Its `validate()` method returns `false`
2. Its `validate()` method returns an object

Option 2) allows validators to supply the `errors` object with additional data.

Due to latest changes to `errorMessage` handling in validators, those messages
would not be rendered anymore if a validator returns simply `false` instead of an object.
The reason for that is because the code assumed that only option 2) is gonna happen.

This commit ensures that error messages a displayed in both options.