### PR TITLE
fix(StatusSlider) made slider flexible

### DIFF
--- a/src/StatusQ/Controls/StatusSlider.qml
+++ b/src/StatusQ/Controls/StatusSlider.qml
@@ -15,8 +15,10 @@ Slider {
     leftPadding: 0
 
     background: Rectangle {
-        implicitHeight: 4
+        id: bgRect
         implicitWidth: 100
+        implicitHeight: 4
+        height: implicitHeight
         color: {
             if (statusSlider.value === statusSlider.to) {
                 return Theme.palette.primaryColor1
@@ -40,7 +42,7 @@ Slider {
 
     handle: Rectangle {
         x: statusSlider.leftPadding + statusSlider.visualPosition * (statusSlider.availableWidth - width / 2)
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenter: bgRect.verticalCenter
         color: Theme.palette.white
         implicitWidth: 28
         implicitHeight: 28


### PR DESCRIPTION
Made slider background and handle to not depend
to root's height so that it covers cases where a
legend is needed thus all should be clickable for
better user experience.

Relates to status-im/status-desktop#3984