### PR TITLE
fix(StatusListItem): This solves the issue of channel list overlapping when a category is collapsed.

### DIFF
--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -106,6 +106,7 @@ Rectangle {
         cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         hoverEnabled: true
+        preventStealing: true
 
         onClicked: {
             statusListItem.clicked(statusListItem.itemId)


### PR DESCRIPTION
fix(StatusListItem): This solves the issue of channel list overlapping when a category is collapsed. 

The issue is not reproducible a 100% of time. In order to solve this bug, we have turned on the preventStealing flag for the mouseArea.
Checked for any side impacts but didn't find any.
Tried several times and this change seems to solve the bug. Feel free to reopen if you are still able to reproduce this behavior.

fixes #4047