### PR TITLE
feat(StatusModal): introduce `hasCloseButton` property

### DIFF
--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -18,6 +18,7 @@ QC.Popup {
     property alias leftButtons: footerImpl.leftButtons
     property bool showHeader: true
     property bool showFooter: true
+    property alias hasCloseButton: headerImpl.hasCloseButton
 
     signal editButtonClicked()
     signal headerImageClicked()

--- a/src/StatusQ/Popups/statusModal/StatusModalHeader.qml
+++ b/src/StatusQ/Popups/statusModal/StatusModalHeader.qml
@@ -19,6 +19,7 @@ Rectangle {
     property alias icon: imageWithTitle.icon
     property bool editable: false
     property alias headerImageEditable: imageWithTitle.headerImageEditable
+    property bool hasCloseButton: true
     property Component popupMenu
 
     signal editButtonClicked
@@ -76,7 +77,7 @@ Rectangle {
     Loader {
         id: actionButtonLoader
         objectName: "actionButtonloader"
-        anchors.right: closeButton.left
+        anchors.right: closeButton.visible ? closeButton.left : parent.right
         anchors.rightMargin: 8
         anchors.top: parent.top
         anchors.topMargin: 16
@@ -96,6 +97,7 @@ Rectangle {
         icon.color: Theme.palette.directColor1
         icon.width: 20
         icon.height: 20
+        visible: statusModalHeader.hasCloseButton
 
         onClicked: statusModalHeader.close()
     }


### PR DESCRIPTION
This property can be used to hide the close button, as there are some
modals that shouldn't allow users to "x" modals away.