### PR TITLE
fix(StatusChatList): unexisting property name for chat item fixed

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -95,7 +95,7 @@ Column {
                     opacity: dragSensor.active ? 0.0 : 1.0
                     originalOrder: model.position
                     chatId: model.itemId
-                    categoryId: model.parentItemId
+                    categoryId: model.parentItemId? model.parentItemId : ""
                     name: model.name
                     type: !!model.type ? model.type : StatusChatListItem.Type.CommunityChat
                     muted: model.muted


### PR DESCRIPTION
`StatusChatList` component is able to display:
- chats for Chat section
- channels for Community section
- channels from a category from Community section

in cases 1. and 2. displayed items do not have `parentItemId` property and
it's not used in these cases.
This commit fixes that console error.