### PR TITLE
refactor: fix empty categories handling

### DIFF
--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -76,7 +76,7 @@ Item {
                 draggableItems: statusChatListAndCategories.draggableItems
                 model: statusChatListAndCategories.model
                 filterFn: function (model) {
-                    return (model.subItems.count === 0)
+                    return !model.isCategory
                 }
                 popupMenu: statusChatListAndCategories.chatListPopupMenu
             }

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -35,7 +35,7 @@ Column {
     StatusChatListCategoryItem {
         id: statusChatListCategoryItem
         title: statusChatListCategory.name
-        visible: (model.subItems.count > 0)
+        visible: model.isCategory
         opened: statusChatListCategory.opened
         sensor.pressAndHoldInterval: 150
 


### PR DESCRIPTION
Fixes an issue where categories with no channels are being displayed as if they were normal channels:
![image](https://user-images.githubusercontent.com/1106587/151396676-74a84929-b6bf-4198-ae09-f844b062b580.png)

While with this change, they look like this:
![image](https://user-images.githubusercontent.com/1106587/151396853-774a7c78-0e4a-4fb2-b269-e5550c85923e.png)
