### PR TITLE
fix: Icon components had wrong color in sandbox app

### DIFF
--- a/sandbox/main.qml
+++ b/sandbox/main.qml
@@ -273,7 +273,12 @@ StatusWindow {
                         Loader {
                             id: viewLoader
                             anchors.centerIn: parent
-                            source: control("Icons")
+                            source: mainPageView.control("Icons")
+                            onSourceChanged: {
+                                if (source.toString().includes("Icons")) {
+                                    item.iconColor = Theme.palette.primaryColor1;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Icon color in Icons page was broken as setting it
in main.qml was mistakenly removed. Set it back to
Theme.palette.primaryColor1

Closes #538
<img width="1336" alt="wtheme" src="https://user-images.githubusercontent.com/31625338/151867385-dfc8e5d2-f4e4-4d43-9056-5237080ed0ce.png">
<img width="1336" alt="dtheme" src="https://user-images.githubusercontent.com/31625338/151867392-ea4b278a-4252-4160-9935-705a4be35416.png">

