### PR TITLE
fix(StatusQ.Popups): removed overlay setting

### DIFF
--- a/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -21,8 +21,6 @@ Menu {
     property var closeHandler
 
     dim: true
-    Overlay.modeless: MouseArea {}
-
 
     signal menuItemClicked(int menuIndex)
 


### PR DESCRIPTION
A MouseArea was set as an Overlay to the PopupMenu consuming all clicks outside the component until it was closed. Removed it as it's not necessary anymore.

Closes https://github.com/status-im/status-desktop/issues/3599