### PR TITLE
fix(StatusListItem): add propagateTitleClicks property to StatusListItem

### DIFF
--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -20,6 +20,7 @@ Rectangle {
     property real rightPadding: 16
     property bool enabled: true
     property bool highlighted: false
+    property bool propagateTitleClicks: true 
     property int type: StatusListItem.Type.Primary
     property list<Item> components
 
@@ -175,7 +176,7 @@ Rectangle {
                     anchors.fill: parent
                     cursorShape: containsMouse? Qt.PointingHandCursor : Qt.ArrowCursor
                     hoverEnabled: true
-                    propagateComposedEvents: true
+                    propagateComposedEvents: statusListItem.propagateTitleClicks
                     onClicked: {
                         statusListItem.titleClicked(statusListItem.titleId)
                         mouse.accepted = false

--- a/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -10,6 +10,7 @@ StatusPopupMenu {
 
     property var searchPopup
     property var locationModel
+    readonly property int numDefaultItems: 2
 
     signal itemClicked(string firstLevelItemValue, string secondLevelItemValue)
 
@@ -43,7 +44,7 @@ StatusPopupMenu {
                                     color: model.iconColor,
                                     isLetterIdenticon: !model.imageSource && !model.iconName
                                    });
-                    root.insertMenu(index+2, item);
+                    root.insertMenu(index + numDefaultItems, item);
                 } else {
                     item.value = model.value
                     item.text = model.title;
@@ -52,7 +53,7 @@ StatusPopupMenu {
                     item.iconSettings.isLetterIdenticon = !model.imageSource && !model.iconName
                     item.image.source = model.imageSource;
                     item.image.isIdenticon = model.isIdenticon;
-                    root.insertItem(index+2, item);
+                    root.insertItem(index + numDefaultItems, item);
                 }
             }
         }

--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -24,6 +24,9 @@ StatusModal {
     property Menu searchOptionsPopupMenu: Menu { }
     property var searchResults: [ ]
     property var searchSelectionButton
+    // This function is called to know if the popup accepts clicks in the title
+    // If it does not, the clicks on the titles mousearea will be propagated to the main body instead
+    property var acceptsTitleClick: function(titleId) {return true}
 
     signal resultItemClicked(string itemId)
     signal resultItemTitleClicked(string titleId)
@@ -275,8 +278,11 @@ StatusModal {
                             root.resultItemClicked(itemId)
                         }
 
+                        propagateTitleClicks: !root.acceptsTitleClick(titleId)
                         onTitleClicked: {
-                            root.resultItemTitleClicked(titleId)
+                            if (root.acceptsTitleClick(titleId)) {
+                                root.resultItemTitleClicked(titleId)
+                            }
                         }
                     }
                     section.property: "sectionName"


### PR DESCRIPTION
Makes it possible disable the propagation of the mouse event when it's not wanted, for example in the search popup, where if the user clicks the title, we want to show the profile popup, but not navigate to the channel

The original isn't changed  for other components using StatusListItem, since the property start at true

This was needed to fix the issue found by Abhi here: https://github.com/status-im/status-desktop/pull/4803#issuecomment-1043064425