### PR TITLE
feat(StatusInput): Add ignore invalid input option to StatusInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Makefile
 *_qmlcache.qrc
 sandbox/qmlcache_loader.cpp
 doc/html
+CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Makefile
 sandbox/qmlcache_loader.cpp
 doc/html
 CMakeLists.txt.user
+.vscode

--- a/sandbox/pages/StatusInputPage.qml
+++ b/sandbox/pages/StatusInputPage.qml
@@ -103,6 +103,20 @@ Column {
     }
 
     StatusInput {
+        label: "Input with <i>StatusRegularExpressionValidator</i>"
+        charLimit: 30
+        input.placeholderText: `Must match regex(${validators[0].regularExpression.toString()}) and <= 30 chars`
+        validationMode: StatusInput.ValidationMode.IgnoreInvalidInput
+
+        validators: [
+            StatusRegularExpressionValidator {
+                regularExpression: /^[0-9A-Za-z_\$-\s]*$/
+                errorMessage: "Bad input!"
+            }
+        ]
+    }
+
+    StatusInput {
         label: "Label"
         input.placeholderText: "Input width component (right side)"
         input.component: StatusIcon {

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -15,7 +15,7 @@ Column {
     width: 288
 
     property string categoryId: ""
-    property var model: []
+    property var model: null
     property bool draggableItems: false
 
     property alias statusChatListItems: statusChatListItems

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -256,7 +256,7 @@ Rectangle {
             anchors.top: iconOrImage.bottom
             anchors.left: parent.left
             anchors.leftMargin: 16
-            width: contentItem.width
+            width: statusListItemBadge.width
             spacing: 10
             anchors.verticalCenter: parent.verticalCenter
 

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -6,6 +6,30 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
+/*!
+   \qmltype StatusInput
+   \inherits Item
+   \inqmlmodule StatusQ.Controls
+   \since StatusQ.Controls 0.1
+   \brief The StatusInput control provides a generic user text input
+
+
+
+   Example of how to use it:
+
+   \qml
+        StatusInput {
+            label: "Label"
+            charLimit: 30
+            errorMessage: "Input doesn't match validator"
+
+            input.clearable: true
+            input.placeholderText: "Placeholder text"
+        }
+   \endqml
+
+   For a list of components available see StatusQ.
+*/
 Item {
     id: root
     implicitWidth: 480
@@ -35,6 +59,28 @@ Item {
     property real rightPadding: 16
     property list<StatusValidator> validators
     property list<StatusAsyncValidator> asyncValidators
+    /*!
+       \qmlproperty int (enumeration ValidationMode)
+        This property describes the validation mode
+
+        Note that this property should be always strictly compared with one of ValidationMode's value
+
+        Default value: StatusInput.ValidationMode.OnlyWhenDirty
+
+        Examples of usage
+
+        > To ignore invalid input
+        \qml
+        StatusInput {
+            validationMode: StatusInput.ValidationMode.IgnoreInvalidInput
+            validators: [
+                StatusMinLengthValidator {
+                    minLength: 15
+                }
+            ]
+        }
+        \endqml
+    */
     property int validationMode: StatusInput.ValidationMode.OnlyWhenDirty
     property string validatedValue
 
@@ -42,6 +88,23 @@ Item {
 
     signal iconClicked()
 
+    /*!
+       \qmltype ValidationMode
+       \brief Available validation modes supported by StatusInput
+
+        Values:
+
+        - OnlyWhenDirty validates input only after it has become dirty
+        - Always validates input even before it has become dirty
+        - IgnoreInvalidInput ignore the new content if it doesn't match validators
+
+       Has no effect without at least a validator
+
+       \note that it represents a QML enumeration and can't be used as a property type, we use int instead
+
+       \see validationMode for a usage example
+       \see validators
+    */
     enum ValidationMode {
         OnlyWhenDirty, // validates input only after it has become dirty
         Always, // validates input even before it has become dirty

--- a/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
+++ b/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
@@ -50,7 +50,7 @@ StatusValidator {
     property var regularExpression
 
     name: "regex"
-    errorMessage: "Please enter a valid regular expression."
+    errorMessage: `Must match regex(${validatorObj.regularExpression.toString()})`
     validatorObj: RegularExpressionValidator { regularExpression: root.regularExpression }
 
     validate: function (value) {

--- a/tests/TestControls/CMakeLists.txt
+++ b/tests/TestControls/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestStatusInputWithRegex LANGUAGES CXX)
+
+enable_testing()
+
+# TODO: Workaround until we make StatusQ a CMake library
+list(APPEND QML_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../src/")
+set(QML_IMPORT_PATH "${QML_DIRS}" CACHE STRING "Qt Creator extra qml import paths")
+set(QML2_IMPORT_PATH "${QML_DIRS}" CACHE STRING "Qt Creator extra qml import paths")
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS QuickTest Qml REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS QuickTest Qml REQUIRED)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# no need to copy around qml test files for shadow builds - just set the respective define
+add_definitions(-DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_executable(TestStatusInputWithRegex main.cpp)
+add_test(NAME TestStatusInputWithRegex COMMAND TestStatusInputWithRegex)
+
+target_link_libraries(TestStatusInputWithRegex PRIVATE
+    Qt${QT_VERSION_MAJOR}::QuickTest
+    Qt${QT_VERSION_MAJOR}::Qml)
+

--- a/tests/TestControls/main.cpp
+++ b/tests/TestControls/main.cpp
@@ -1,0 +1,21 @@
+#include <QtQuickTest/quicktest.h>
+#include <QQmlEngine>
+
+class TestSetup : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestSetup() {}
+
+public slots:
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        // TODO: Workaround until we make StatusQ a CMake library
+        engine->addImportPath("../../src/");
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(TestControls, TestSetup)
+
+#include "main.moc"

--- a/tests/TestControls/tst_test-statusinput.qml
+++ b/tests/TestControls/tst_test-statusinput.qml
@@ -1,0 +1,85 @@
+import QtQuick 2.0
+import QtTest 1.0
+
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+
+Item {
+    width: 300
+    height: 100
+
+    property int _defaultValidationMode
+
+    Component.onCompleted: {
+        _defaultValidationMode = statusInput.validationMode
+    }
+    StatusInput {
+        id: statusInput
+        label: "Control under test"
+        charLimit: 30
+        input.placeholderText: `Must match regex(${validators[0].regularExpression.toString()}) and <= 30 chars`
+        focus: true
+
+        validators: [
+            StatusRegularExpressionValidator {
+                regularExpression: /^[0-9A-Za-z_\$-\s]*$/
+            }
+        ]
+    }
+
+    TestCase {
+        name: "RegexValidationTest"
+
+        when: windowShown
+
+        //
+        // Test guards
+        function initTestCase() {
+            mouseClick(statusInput)
+        }
+
+        function cleanup() {
+            statusInput.text = ""
+            statusInput.validationMode = _defaultValidationMode
+        }
+
+        //
+        // Tests
+        function test_initial_empty_is_valid() {
+            verify(statusInput.valid, "Expected valid input")
+        }
+
+        function test_regex_validation() {
+            keyClick(Qt.Key_1)
+            verify(statusInput.valid, "Expected valid input")
+            keyClick(Qt.Key_Ampersand)
+            verify(!statusInput.valid, "Expected invalid input")
+        }
+
+        function test_no_invalid_input() {
+            statusInput.validationMode = StatusInput.ValidationMode.IgnoreInvalidInput
+
+            verify(statusInput.valid, "Expected valid input")
+            verify(statusInput.text.length === 0, "Expected no input")
+            keyClick(Qt.Key_2)
+            verify(statusInput.valid, "Expected valid input")
+            verify(statusInput.text === "2", "Expect one character")
+            keyClick(Qt.Key_Ampersand)
+            verify(statusInput.valid, "Expected invalid input")
+            verify(statusInput.text === "2", "Expect the same input")
+        }
+
+        // Use case expected in case new validation changes are enabled with old unvalid data
+        function test_user_can_delete_initial_invalid_input() {
+            const appendInvalidChars = "#@!*"
+
+            statusInput.text = "invalid $" + appendInvalidChars
+            keyClick(Qt.Key_End)
+            verify(!statusInput.valid, "Expected invalid input due to characters not matching")
+            // Delete invalid characters to get a valid text
+            for(let i = 0; i < appendInvalidChars.length; ++i)
+                keyClick(Qt.Key_Backspace)
+            verify(statusInput.valid, "Expected valid input")
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- [x] test the validator
- [x] add an optional feature to StatusInput not to allow typing characters that are not validated
- [x] add a test entry in the sandbox app.
- [x] add basic documentation

Required for merging #5010

## Screenshots

New entry
![image](https://user-images.githubusercontent.com/47554641/157698697-b023f7b9-731b-4f68-b3d9-dfc0dba8ec8c.png)

Allow typing only what matches regex
![image](https://user-images.githubusercontent.com/47554641/157699706-c6b8f367-192d-4317-8f05-d92661b219bc.png)

updates #4961