### PR TITLE
fix(StatusIconSettings): set charactersLen to 1 by default

### DIFF
--- a/src/StatusQ/Core/StatusIconSettings.qml
+++ b/src/StatusQ/Core/StatusIconSettings.qml
@@ -14,7 +14,7 @@ QtObject {
     property int rotation
     property bool isLetterIdenticon
     property int letterSize
-    property int charactersLen
+    property int charactersLen: 1
     property string emoji
     property string emojiSize
     property StatusIconBackgroundSettings background: StatusIconBackgroundSettings {}


### PR DESCRIPTION
This caused a breaking change where components that used to imply 1 charactersLen now showed no character at all because it defaulted to 0.

Fixes https://github.com/status-im/status-desktop/issues/5078