### PR TITLE
fix(StatusQ.Popups): Replace TextEdit to StatusBaseInput for SearchPopup

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -51,6 +51,7 @@ Item {
     property bool pending: false
     property bool leftIcon: true
     property bool isIconSelectable: false
+    property bool showBackground: true
 
     property StatusIconSettings icon: StatusIconSettings {
         width: 24
@@ -84,13 +85,17 @@ Item {
                                                     root.implicitHeight,
                                                     minimumHeight) : root.implicitHeight,
                                          maximumHeight) : parent.height
-        color: Theme.palette.baseColor2
+        color: root.showBackground ? Theme.palette.baseColor2
+                                              : "transparent"
         radius: 8
 
         clip: true
 
         border.width: 1
         border.color: {
+            if (!root.showBackground) {
+                return "transparent"
+            }
             if (!root.valid && root.dirty) {
                 return Theme.palette.dangerColor1
             }

--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -55,7 +55,7 @@ StatusModal {
     }
 
     function forceActiveFocus() {
-        contentItem.searchInput.forceActiveFocus()
+        contentItem.searchInput.edit.forceActiveFocus()
     }
 
     onOpened: {
@@ -85,7 +85,8 @@ StatusModal {
                     icon: "search"
                     color: Theme.palette.baseColor1
                 }
-                TextEdit {
+
+                StatusBaseInput {
                     id: inputText
                     anchors.left: statusIcon.right
                     anchors.leftMargin: 15
@@ -94,6 +95,8 @@ StatusModal {
                     anchors.verticalCenter: parent.verticalCenter
                     focus: true
                     font.pixelSize: 28
+                    clearable: true
+                    showBackground: false
                     font.family: Theme.palette.baseFont.name
                     color: Theme.palette.directColor1
                     Keys.onPressed: {


### PR DESCRIPTION
Closes: https://github.com/status-im/status-desktop/issues/5059

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
