### PR TITLE
fix(SeedPhraseInput): Fixing SeedPhraseInput control height

### DIFF
--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.12
 import QtGraphicalEffects 1.13
+import QtQuick.Controls 2.12
 
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
@@ -55,7 +56,7 @@ Item {
     Item {
         id: suggListContainer
         width: seedSuggestionsList.width
-        height: (seedSuggestionsList.count*34) + 16
+        height: (((seedSuggestionsList.count <= 5) ? seedSuggestionsList.count : 5) *34) + 16
         anchors.left: parent.left
         anchors.leftMargin: 16
         anchors.top: seedWordInput.bottom
@@ -87,6 +88,7 @@ Item {
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 8
             clip: true
+            ScrollBar.vertical: ScrollBar { }
             delegate: Item {
                 id: txtDelegate
                 width: suggWord.contentWidth


### PR DESCRIPTION
The suggestion list should be showing up to 5 seed
word entries

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
