### PR TITLE
fix(StatusChatListCategory): Selecting the category menu should not toggle the category itself

### DIFF
--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -48,7 +48,6 @@ Column {
                     popupMenuSlot.item.popup(mouse.x + 4, mouse.y + 6);
                     return
                 }
-                statusChatListCategory.opened = !opened;
             }
         }
         onTitleClicked: statusChatListCategory.opened = !opened


### PR DESCRIPTION
Closes `status-desktop` issue https://github.com/status-im/status-desktop/issues/4914
