### PR TITLE
fix(StatusBaseInput): fix default padding when leftComponent is loaded

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -37,7 +37,7 @@ Item {
     property alias placeholderTextColor: placeholder.color
     property alias placeholderFont: placeholder.font
 
-    property real leftPadding: 16
+    property real leftPadding: leftComponentLoader.item ? 8 : 16
     property real rightPadding: 16
     property real topPadding: 12
     property real bottomPadding: 12
@@ -127,6 +127,7 @@ Item {
                 clip: true
 
                 Loader {
+                    id: leftComponentLoader
                     sourceComponent: {
                         if (root.leftComponent) return root.leftComponent
                         if (!root.leftIcon) return undefined


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/33099791/160395364-f8832af9-3bb2-4f33-9ce0-3cc207563b2c.png)
After:
![image](https://user-images.githubusercontent.com/33099791/160397248-93f0184d-1532-4aff-b5a5-894a7f651dd4.png)
---
### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
