### PR TITLE
fix(StatusBaseInput): placeholder position update

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -176,7 +176,7 @@ Item {
 
                         width: flick.width
                         height: flick.height
-                        verticalAlignment: Text.AlignVCenter
+                        verticalAlignment: TextEdit.AlignVCenter
                         selectByMouse: true
                         selectionColor: Theme.palette.primaryColor2
                         selectedTextColor: color
@@ -217,10 +217,8 @@ Item {
                         StatusBaseText {
                             id: placeholder
                             visible: (edit.text.length === 0)
-                            anchors.left: parent.left
-                            anchors.right: parent.right
-                            anchors.rightMargin: root.rightPadding
-                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.fill: parent
+                            verticalAlignment: parent.verticalAlignment
                             font.pixelSize: 15
                             elide: StatusBaseText.ElideRight
                             font.family: Theme.palette.baseFont.name


### PR DESCRIPTION
Placeholder text position updated for the `StatusBaseInput` component
that it follows the set text position.

This change is needed because of [this comment](https://github.com/status-im/status-desktop/pull/5245#issuecomment-1082310003).

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
