### PR TITLE
fix(StatusSeedPhraseInput): remove empty spaces in seed phrase input

### DIFF
--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -90,7 +90,7 @@ Item {
                 seedSuggestionsList.model = filteredList;
                 if ((text.length === 4) && (filteredList.count === 1) &&
                     ((input.edit.keyEvent !== Qt.Key_Backspace) && (input.edit.keyEvent !== Qt.Key_Delete))) {
-                    seedWordInput.text = filteredList.get(0).seedWord;
+                    seedWordInput.text = filteredList.get(0).seedWord.trim();
                     seedWordInput.input.edit.cursorPosition = seedWordInput.text.length;
                     seedSuggestionsList.model = 0;
                     root.doneInsertingWord(seedWordInput.text);


### PR DESCRIPTION
### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
