### PR TITLE
fix(StatusPickerButton): Added property `textPixelSize` to be configurable

### DIFF
--- a/src/StatusQ/Controls/StatusPickerButton.qml
+++ b/src/StatusQ/Controls/StatusPickerButton.qml
@@ -13,6 +13,7 @@ Button {
     property color contentColor: Theme.palette.baseColor1
     property var type: StatusPickerButton.Type.Next
     property int lateralMargins: 16
+    property int textPixelSize: 15
 
     enum Type {
         Next,
@@ -38,7 +39,7 @@ Button {
             anchors.verticalCenter: parent.verticalCenter
             width: parent.width - icon.width - anchors.rightMargin - anchors.leftMargin - icon.anchors.rightMargin - icon.anchors.leftMargin
             verticalAlignment: Text.AlignVCenter
-            font.pixelSize: 15
+            font.pixelSize: root.textPixelSize
             color: root.contentColor
             text: root.text
             clip: true


### PR DESCRIPTION
Added property `textPixelSize` to be configurable in `StatusPickerButton`.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
