### PR TITLE
Fix/profile image fallback color

### DIFF
--- a/sandbox/controls/Others.qml
+++ b/sandbox/controls/Others.qml
@@ -4,38 +4,58 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 
-GridLayout {
-    columns: 6
-    columnSpacing: 5
-    rowSpacing: 5
+ColumnLayout {
+    GridLayout {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
-    StatusLoadingIndicator {
-        color: Theme.palette.directColor4
+        columns: 6
+        columnSpacing: 5
+        rowSpacing: 5
+
+        StatusLoadingIndicator {
+            color: Theme.palette.directColor4
+        }
+
+        StatusLetterIdenticon {
+            name: "#status"
+        }
+
+        StatusRoundedImage {
+            image.source: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
+        }
+
+        StatusBadge {}
+
+        StatusBadge {
+            value: 1
+        }
+
+        StatusBadge {
+            value: 10
+        }
+
+        StatusBadge {
+            value: 100
+        }
+
+        StatusRoundIcon {
+            icon.name: "info"
+        }
     }
 
-    StatusLetterIdenticon {
-        name: "#status"
-    }
+    Flow {
+        Layout.fillWidth: true
+        spacing: 4
 
-    StatusRoundedImage {
-        image.source: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
-    }
-
-    StatusBadge {}
-
-    StatusBadge {
-        value: 1
-    }
-
-    StatusBadge {
-        value: 10
-    }
-
-    StatusBadge {
-        value: 100
-    }
-
-    StatusRoundIcon {
-        icon.name: "info"
+        Repeater {
+            model: 12
+            StatusLetterIdenticon {
+                name: "A"
+                color: Theme.palette.userCustomizationColors[index]
+                letterSize: 16
+            }
+        }
     }
 }
+

--- a/sandbox/pages/StatusWalletColorSelectPage.qml
+++ b/sandbox/pages/StatusWalletColorSelectPage.qml
@@ -12,6 +12,6 @@ Column {
     spacing: 8
 
     StatusWalletColorSelect {
-        model: Theme.palette.accountColors
+        model: Theme.palette.userCustomizationColors
     }
 }

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -105,7 +105,7 @@ Column {
                     selected: model.active
 
                     icon.emoji: model.emoji
-                    icon.color: model.color
+                    icon.color: !!model.color ? model.color : Theme.palette.userCustomizationColors[model.colorId]
                     image.isIdenticon: false
                     image.source: model.icon
                     ringSettings.ringSpecModel: model.colorHash

--- a/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -29,7 +29,7 @@ Rectangle {
 
         font.weight: Font.Bold
         font.pixelSize: root.letterSize
-        color: Qt.rgba(255, 255, 255, 0.7)
+        color: d.luminance(root.color) > 0.5 ? Qt.rgba(0, 0, 0, 0.5) : Qt.rgba(255, 255, 255, 0.7)
 
         text: {
             if (emoji) {
@@ -43,6 +43,16 @@ Rectangle {
                           (root.name.charAt(0) === "@")
 
             return root.name.substring(shift, shift + charactersLen).toUpperCase()
+        }
+    }
+
+    QtObject {
+        id: d
+        function luminance(color) {
+            let r = Math.pow(color.r, 2.2) * 0.2126
+            let g = Math.pow(color.g, 2.2) * 0.7151
+            let b = Math.pow(color.b, 2.2) * 0.0721
+            return r + g + b
         }
     }
 }

--- a/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -86,7 +86,6 @@ Loader {
             emoji: statusSmartIdenticon.icon.emoji
             emojiSize: statusSmartIdenticon.icon.emojiSize
             letterSize: statusSmartIdenticon.icon.letterSize
-            identiconText.color: statusSmartIdenticon.icon.textColor
             charactersLen: statusSmartIdenticon.icon.charactersLen
         }
     }

--- a/src/StatusQ/Controls/StatusAccountSelector.qml
+++ b/src/StatusQ/Controls/StatusAccountSelector.qml
@@ -55,7 +55,7 @@ Item {
             return
         }
         if (selectedAccount.color) {
-            selectedIconImg.color = Utils.getThemeAccountColor(selectedAccount.color, Theme.palette.accountColors) || Theme.palette.accountColors[0]
+            selectedIconImg.color = Utils.getThemeAccountColor(selectedAccount.color, Theme.palette.userCustomizationColors) || Theme.palette.userCustomizationColors[0]
         }
         if (selectedAccount.name) {
             selectedTextField.text = selectedAccount.name
@@ -208,7 +208,7 @@ Item {
                 width: 20
                 height: 20
                 icon: "filled-account"
-                color: Utils.getThemeAccountColor(model.color, Theme.palette.accountColors) || Theme.palette.accountColors[0]
+                color: Utils.getThemeAccountColor(model.color, Theme.palette.userCustomizationColors) || Theme.palette.userCustomizationColors[0]
             }
 
             Column {

--- a/src/StatusQ/Controls/StatusIdenticonRing.qml
+++ b/src/StatusQ/Controls/StatusIdenticonRing.qml
@@ -141,6 +141,11 @@ Item {
                     }
                 }
             }
+
+            Connections {
+                target: root.settings
+                onRingSpecModelChanged: requestPaint()
+            }
         }
     }
 }

--- a/src/StatusQ/Controls/StatusWalletColorSelect.qml
+++ b/src/StatusQ/Controls/StatusWalletColorSelect.qml
@@ -45,7 +45,7 @@ Item {
                         return true
                     }
                     // Check the colors in the other theme
-                    const currentColor = Utils.getThemeAccountColor(upperCaseColor, Theme.palette.accountColors)
+                    const currentColor = Utils.getThemeAccountColor(upperCaseColor, Theme.palette.userCustomizationColors)
                     if (!currentColor) {
                         return false
                     }

--- a/src/StatusQ/Core/StatusIconSettings.qml
+++ b/src/StatusQ/Core/StatusIconSettings.qml
@@ -8,7 +8,6 @@ QtObject {
     property real width
     property real height
     property color color
-    property color textColor: Qt.rgba(255, 255, 255, 0.7)
     property color disabledColor
     property url source
     property int rotation

--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -147,15 +147,19 @@ ThemePalette {
     miscColor11: getColor('yellow2')
     miscColor12: getColor('green6')
 
-    accountColors: [
-        getColor('blue5'),
-        getColor('yellow2'),
-        "#E6ABFC",
-        getColor('moss2'),
-        "#FB8383",
-        getColor('green4'),
-        "#ADA3FF",
-        getColor('brown3')
+    userCustomizationColors: [
+        "#AAC6FF",
+        "#887AF9",
+        "#51D0F0",
+        "#D37EF4",
+        "#FA6565",
+        "#FFCA0F",
+        "#93DB33",
+        "#10A88E",
+        "#AD4343",
+        "#EAD27B",
+        "silver", // update me when figma is ready
+        "darkgrey", // update me when figma is ready
     ]
 
     identiconRingColors: ["#000000", "#726F6F", "#C4C4C4", "#E7E7E7", "#FFFFFF", "#00FF00",

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -145,15 +145,19 @@ ThemePalette {
     miscColor11: getColor('brown2')
     miscColor12: getColor('green5')
 
-    accountColors: [
-        getColor('blue'),
-        getColor('brown2'),
-        getColor('violet'),
-        "#1D806F",
-        getColor('red2'),
-        getColor('green2'),
-        getColor('purple'),
-        getColor('brown')
+    userCustomizationColors: [
+        "#2946C4",
+        "#887AF9",
+        "#51D0F0",
+        "#D37EF4",
+        "#FA6565",
+        "#FFCA0F",
+        "#7CDA00",
+        "#26A69A",
+        "#8B3131",
+        "#9B832F",
+        "silver", // update me when figma is ready
+        "darkgrey", // update me when figma is ready
     ]
 
     identiconRingColors: ["#000000", "#726F6F", "#C4C4C4", "#E7E7E7", "#FFFFFF", "#00FF00",

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -90,7 +90,7 @@ QtObject {
     property color miscColor11
     property color miscColor12
 
-    property var accountColors: []
+    property var userCustomizationColors: []
 
     property var identiconRingColors: []
 


### PR DESCRIPTION
required by: https://github.com/status-im/status-desktop/pull/5424

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [x] is this a breaking change?
    - [x] use the dedicated `BREAKING CHANGE` commit message section
    - [x] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [x] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
