### PR TITLE
fix(@desktop/chat): Fix displaying a list of contacts in StatusTagSelector

### DIFF
--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -60,8 +60,9 @@ Item {
     id: root
 
     implicitWidth: 448
-    implicitHeight: 44 + ((userListView.count > 0) ? 44 + contactsLabel.height + contactsLabel.anchors.topMargin + ((((userListView.count * 64) > root.maxHeight)
-                    ? root.maxHeight : (userListView.count * 64))) :0)
+    implicitHeight: 44 + ((userListView.model.count > 0) ? 44 + contactsLabel.height + contactsLabel.anchors.topMargin +
+                    ((((userListView.model.count * 64) > root.maxHeight) ? root.maxHeight : (userListView.model.count * 64))) :0)
+
     /*!
         \qmlproperty real StatusTagSelector::maxHeight
         This property holds the maximum height of the component.
@@ -139,9 +140,9 @@ Item {
             for (var i = 0; i < inputModel.count; i++ ) {
                 var entry = inputModel.get(i);
                 if (entry.name.toLowerCase().includes(text.toLowerCase())) {
-                    sortedList.insert(sortedList.count, {"publicId": entry.publicId, "name": entry.name,
-                                          "icon": entry.icon, "isIdenticon": entry.isIdenticon,
-                                          "onlineStatus": entry.onlineStatus});
+                    sortedList.append({"publicId": entry.publicId, "name": entry.name,
+                                       "icon": entry.icon, "isIdenticon": entry.isIdenticon,
+                                       "onlineStatus": entry.onlineStatus});
                     userListView.model = sortedList;
                 }
             }


### PR DESCRIPTION
Fix #5465

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
