### PR TITLE
fix(StatusListPicker): Disabled uncheck option and reset searcher

### DIFF
--- a/sandbox/pages/StatusListPickerPage.qml
+++ b/sandbox/pages/StatusListPickerPage.qml
@@ -24,27 +24,27 @@ GridLayout {
             id: languagePicker
             z: 100
             inputList: Models.languagePickerModel
-            searchText: qsTr("Search Languages")
+            placeholderSearchText: qsTr("Search Languages")
         }
 
         StatusListPicker {
             id: languagePicker2
             z: 100
             inputList: Models.languageNoImagePickerModel
-            searchText: qsTr("Search Languages")
+            placeholderSearchText: qsTr("Search Languages")
         }
 
         StatusListPicker {
             id: currencyPicker
             inputList: Models.currencyPickerModel
-            searchText: qsTr("Search Currencies")
+            placeholderSearchText: qsTr("Search Currencies")
             multiSelection: true
         }
 
         StatusListPicker {
             id: currencyPicker2
             inputList: Models.currencyPickerModel2
-            searchText: qsTr("Search Currencies")
+            placeholderSearchText: qsTr("Search Currencies")
             multiSelection: true
             printSymbol: true
             enableSelectableItem: false

--- a/src/StatusQ/Components/StatusListPicker.qml
+++ b/src/StatusQ/Components/StatusListPicker.qml
@@ -73,9 +73,15 @@ Item {
 
     /*!
        \qmlproperty string StatusListPicker::searchText
+       This property holds the search text the searcher input displays by default.
+    */
+    property string searchText: ""
+
+    /*!
+       \qmlproperty string StatusListPicker::placeholderSearchText
        This property holds the placeholder text the searcher input displays by default.
     */
-    property string searchText: qsTr("Search")
+    property string placeholderSearchText: qsTr("Search")
 
     /*!
        \qmlproperty string StatusListPicker::multiSelection
@@ -113,7 +119,12 @@ Item {
             }
        \endqml
     */
-    function close() { picker.visible = false }
+    function close() {
+        picker.visible = false
+
+        // Reset searcher:
+        root.searchText = ""
+    }
 
     /*!
         \qmlsignal StatusListPicker::itemPickerChanged(string key, bool selected)
@@ -276,16 +287,20 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     topPadding: 8
                     bottomPadding: 0
-                    placeholderText: root.searchText
+                    placeholderText: root.placeholderSearchText
+                    text: root.searchText
                     icon.name: "search"
 
-                    onTextChanged: { d.applyFilter(text) }
+                    onTextChanged: {
+                        d.applyFilter(text)
+                        root.searchText = text
+                    }
                 }
             }// End of search input item
             delegate: StatusItemPicker {
                 width: content.itemWidth
                 height: content.itemHeight
-                color: mouseArea.containsMouse? Theme.palette.baseColor4 : "transparent"
+                color: mouseArea.containsMouse ? Theme.palette.baseColor4 : "transparent"
                 image: StatusImageSettings {
                     source: model.imageSource ? model.imageSource : ""
                     width: 15
@@ -319,7 +334,15 @@ Item {
                     anchors.fill: parent
                     cursorShape: root.enableSelectableItem ? Qt.PointingHandCursor : Qt.ArrowCursor
                     hoverEnabled: true
-                    onClicked: { selected = !selected }
+                    onClicked: {
+                        if(selectorType === StatusItemPicker.SelectorType.RadioButton) {
+                            // Just only allow to select, not unselect in case of single selection (radiobutton)
+                             if(!selected) selected = !selected
+                        }
+                        else
+                            // In case of multiple selections you can both select and unselect.
+                            selected = !selected
+                    }
                 }
             }
             section.property: "category"


### PR DESCRIPTION
- Disabled uncheck option if component is configured as single selection mode.

- Added binding to reset searcher input text when picker is closed.

BREAKING CHANGE: Renamed `searchText` property for `placeholderSearchText` to control placeholder text in searcher and added / used existing `searchText` property to control  searcher input text.

**IMPORTANT:** Breaking changes will be resolved in the following [PR](https://github.com/status-im/status-desktop/pull/5417) in desktop.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [x] is this a breaking change?
    - [x] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
