### PR TITLE
Improve Seed Input

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -44,6 +44,13 @@ Item {
         This property indicates whether the StatusBaseInput allows multiline text. Default value is false.
     */
     property bool multiline: false
+
+    /*!
+        \qmlproperty bool StatusBaseInput::acceptReturn
+        This property indicates whether the StatusBaseInput allows pressing Enter or Return. 
+        This is used in case multiline is false and we still want to interact using Enter or Return. Default value is false.
+    */
+    property bool acceptReturn: false
     /*!
         \qmlproperty bool StatusBaseInput::clearable
         This property indicates whether the StatusBaseInput allows clearing all text. Default value is false.
@@ -371,8 +378,8 @@ Item {
                         color: Theme.palette.directColor1
                         wrapMode: root.multiline ? Text.WrapAtWordBoundaryOrAnywhere : TextEdit.NoWrap
 
-                        Keys.onReturnPressed: event.accepted = !multiline
-                        Keys.onEnterPressed: event.accepted = !multiline
+                        Keys.onReturnPressed: event.accepted = !multiline && !acceptReturn
+                        Keys.onEnterPressed: event.accepted = !multiline && !acceptReturn
                         Keys.forwardTo: [root]
                         KeyNavigation.priority: !!root.tabNavItem ? KeyNavigation.BeforeItem : KeyNavigation.AfterItem
                         KeyNavigation.tab: root.tabNavItem

--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -131,19 +131,20 @@ Item {
                 return
             }
             filteredList.clear();
-            if (text !== "") {
+            let textToCheck = text.trim()
+            if (textToCheck !== "") {
                 for (var i = 0; i < inputList.count; i++) {
-                    if (inputList.get(i).seedWord.startsWith(text)) {
+                    if (inputList.get(i).seedWord.startsWith(textToCheck)) {
                         filteredList.insert(filteredList.count, {"seedWord": inputList.get(i).seedWord});
                     }
                 }
                 seedSuggestionsList.model = filteredList;
                 if (filteredList.count === 1 && input.edit.keyEvent !== Qt.Key_Backspace
                         && input.edit.keyEvent !== Qt.Key_Delete
-                        && filteredList.get(0).seedWord.trim() === seedWordInput.text) {
-                    seedWordInput.input.edit.cursorPosition = seedWordInput.text.length;
+                        && filteredList.get(0).seedWord.trim() === textToCheck) {
+                    seedWordInput.input.edit.cursorPosition = textToCheck.length;
                     seedSuggestionsList.model = 0;
-                    root.doneInsertingWord(seedWordInput.text);
+                    root.doneInsertingWord(textToCheck);
                 }
             } else {
                 seedSuggestionsList.model = 0;
@@ -211,6 +212,7 @@ Item {
 
             function completeWordFill(seedWord) {
                 seedWordInput.input.edit.text = seedWord.trim();
+                // Changing the text of the input triggers the onTextChanged, thus signalling doneInsertingWord if the condition passes 
                 seedWordInput.input.edit.cursorPosition = seedWordInput.text.length;
             }
 


### PR DESCRIPTION
This is needed for https://github.com/status-im/status-desktop/issues/5409

It improves the SeedInput:
- support up and down arrows to go up and down the suggestion list
- Support tab and enter for auto-complete
- go to next only when word is complete

The StatusBaseInput also has a new prop so that we can pass the return pressed event.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
