### PR TITLE
fix(StatusListPicker): Add an option to allign the menu with respective the buttons and keep right alligned as the default one

### DIFF
--- a/sandbox/pages/StatusListPickerPage.qml
+++ b/sandbox/pages/StatusListPickerPage.qml
@@ -25,6 +25,7 @@ GridLayout {
             z: 100
             inputList: Models.languagePickerModel
             placeholderSearchText: qsTr("Search Languages")
+            menuAlignment: StatusListPicker.MenuAlignment.Left
         }
 
         StatusListPicker {
@@ -32,6 +33,7 @@ GridLayout {
             z: 100
             inputList: Models.languageNoImagePickerModel
             placeholderSearchText: qsTr("Search Languages")
+            menuAlignment: StatusListPicker.MenuAlignment.Center
         }
 
         StatusListPicker {

--- a/src/StatusQ/Components/StatusListPicker.qml
+++ b/src/StatusQ/Components/StatusListPicker.qml
@@ -107,6 +107,23 @@ Item {
     */
     property bool enableSelectableItem: true
 
+    /*!
+       \qmlproperty string StatusListPicker::menuAlignment
+       This property holds the allignment of the menu in terms of the button
+    */
+    property int menuAlignment: StatusListPicker.MenuAlignment.Right
+
+    /*!
+       \qmlproperty enum StatusListPicker::MenuAlignment
+       This property holds the allignment of the menu in terms of the button
+       values can be Left, Right or Center
+    */
+    enum MenuAlignment {
+        Left,
+        Right,
+        Center
+    }
+
     /*
         \qmlmethod StatusListPicker::close()
         It can be used to force to close the drop-down picker list whenever the consumer needs it. For example by adding an outside MouseArea to close the picker when user clicks outsite the component:
@@ -240,7 +257,9 @@ Item {
 
         width: content.itemWidth
         height: Math.min(content.contentHeight + content.anchors.topMargin + content.anchors.bottomMargin, root.maxPickerHeight)
-        anchors.left: btn.left
+        anchors.left: root.menuAlignment === StatusListPicker.MenuAlignment.Left ? btn.left : undefined
+        anchors.right: root.menuAlignment === StatusListPicker.MenuAlignment.Right ? btn.right : undefined
+        anchors.horizontalCenter: root.menuAlignment === StatusListPicker.MenuAlignment.Center ? btn.horizontalCenter : undefined
         anchors.top: btn.bottom
         anchors.topMargin: 4
         visible: false
@@ -285,7 +304,7 @@ Item {
                     width: content.itemWidth - 2 * 18
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    topPadding: 8
+                    topPadding: 0
                     bottomPadding: 0
                     placeholderText: root.placeholderSearchText
                     text: root.searchText


### PR DESCRIPTION
fix(StatusListPicker): Add an option to allign the menu with respective the buttons and keep right alligned as the default one

fixes #5633

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
