### PR TITLE
fix(StatusBaseButton): After loading, button keeps loader width, so the button size is bigger

### DIFF
--- a/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/src/StatusQ/Controls/StatusBaseButton.qml
@@ -40,11 +40,9 @@ Rectangle {
               return 5
             case StatusBaseButton.Size.Small:
               return 10
-              break;
             case StatusBaseButton.Size.Large:
             default:
               return 11
-              break;
         }
     }
     property real defaultBottomPadding: {
@@ -53,11 +51,9 @@ Rectangle {
               return 5
             case StatusBaseButton.Size.Small:
               return 10
-              break;
             case StatusBaseButton.Size.Large:
             default:
               return 11
-              break;
         }
     }
 
@@ -138,6 +134,7 @@ Rectangle {
             Loader {
                 anchors.verticalCenter: parent.verticalCenter
                 active: loading
+                visible: loading
                 sourceComponent: StatusLoadingIndicator {
                     color: statusBaseButton.enabled ? textColor
                                                     : disabledTextColor


### PR DESCRIPTION
When button changed from loading to their normal shape it kept the width of the loader as it was visible in the row component.

It has been added a binding between loader `visible` property and root `loading` property that fixes the issue with the width.

Also, removed some `break` leftovers.

Fixes #5606 --> https://github.com/status-im/status-desktop/issues/5606

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
