### PR TITLE
fix(StatusBaseInput): fix dirty being set when the text didn't change

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -384,6 +384,10 @@ Item {
                         onCursorRectangleChanged: flick.ensureVisible(cursorRectangle)
                         onActiveFocusChanged: if (root.pristine) root.pristine = false
                         onTextChanged: {
+                            if (previousText === text) {
+                                // Not sure why, but the textChanged event was triggered even if it didn't really
+                                return
+                            }
                             root.dirty = true
                             if (root.maximumLength > 0) {
                                 if (text.length > root.maximumLength) {


### PR DESCRIPTION
Found this issue when I activated the `forceActiveFocus` in the CreateCommunityPopup. It would trigger the red border.

The problem was that the textChanged event would trigger, even though nothing was changed. 

I added this condition to make sure dirty doesn't get flagged.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
