### PR TITLE
fix(StatusBaseButton): Button component should keep its original size when it enters loading state

### DIFF
--- a/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/src/StatusQ/Controls/StatusBaseButton.qml
@@ -105,6 +105,17 @@ Rectangle {
         hoverEnabled: !loading
         enabled: !loading
 
+
+        Loader {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            active: loading
+            sourceComponent: StatusLoadingIndicator {
+                color: statusBaseButton.enabled ? textColor
+                                                : disabledTextColor
+            } // Indicator
+        } // Loader
+
         Row {
             id: layout
             anchors.left: parent.left
@@ -117,29 +128,20 @@ Rectangle {
                 height: statusBaseButton.icon.height
                 icon: statusBaseButton.icon.name
                 anchors.verticalCenter: parent.verticalCenter
-                visible: !loading && statusBaseButton.icon.name !== ""
+                opacity: !loading && statusBaseButton.icon.name !== ""
+                visible: statusBaseButton.icon.name !== ""
                 color: statusBaseButton.enabled ? textColor
                                                 : disabledTextColor
             } // Icon
             StatusBaseText {
                 id: label
-                visible: !loading
+                opacity: !loading
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: size === StatusBaseButton.Size.Large ? 15 : 13 // by design
 
                 color: statusBaseButton.enabled ? textColor
                                                 : disabledTextColor
             } // Text
-
-            Loader {
-                anchors.verticalCenter: parent.verticalCenter
-                active: loading
-                visible: loading
-                sourceComponent: StatusLoadingIndicator {
-                    color: statusBaseButton.enabled ? textColor
-                                                    : disabledTextColor
-                } // Indicator
-            } // Loader
         } // Ro
 
 


### PR DESCRIPTION
…h/size when it enters loading state

fixes #656

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
