### PR TITLE
fix(StatusTagSelector): Added up/down hard keys navigation

### DIFF
--- a/sandbox/demoapp/CreateChatView.qml
+++ b/sandbox/demoapp/CreateChatView.qml
@@ -33,7 +33,10 @@ Page {
             onTextChanged: {
                 sortModel(root.contactsModel);
             }
-            Component.onCompleted: { sortModel(root.contactsModel); }
+            Component.onCompleted: {
+                textEdit.forceActiveFocus();
+                sortModel(root.contactsModel);
+            }
         }
 
         StatusButton {

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -235,7 +235,7 @@ Item {
                 }
             }
 
-            TextEdit {
+            TextInput {
                 id: edit
                 Layout.fillWidth: true
                 Layout.preferredHeight: 44
@@ -244,7 +244,7 @@ Item {
                 enabled: visible
                 focus: true
                 font.pixelSize: 15
-                wrapMode: TextEdit.WrapAnywhere
+                wrapMode: TextEdit.NoWrap
                 font.family: Theme.palette.baseFont.name
                 color: Theme.palette.directColor1
                 Keys.onPressed: {
@@ -254,7 +254,12 @@ Item {
                         removeMember(namesModel.get(namesList.count-1).publicId);
                         namesModel.remove((namesList.count-1), 1);
                     }
+                    if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && (sortedList.count > 0)) {
+                        root.insertTag(sortedList.get(userListView.currentIndex).name, sortedList.get(userListView.currentIndex).publicId);
+                    }
                 }
+                Keys.onUpPressed: { userListView.decrementCurrentIndex(); }
+                Keys.onDownPressed: { userListView.incrementCurrentIndex(); }
             }
 
             StatusBaseText {
@@ -324,12 +329,14 @@ Item {
                 policy: ScrollBar.AsNeeded
             }
             boundsBehavior: Flickable.StopAtBounds
+            onCountChanged: {
+                userListView.currentIndex = 0;
+            }
             delegate: Item {
                 id: wrapper
                 anchors.right: parent.right
                 anchors.left: parent.left
                 height: 64
-                property bool hovered: false
                 Rectangle {
                     id: rectangle
                     anchors.fill: parent
@@ -337,7 +344,7 @@ Item {
                     anchors.leftMargin: 8
                     radius: 8
                     visible: (root.sortedList.count > 0)
-                    color: (wrapper.hovered) ? Theme.palette.baseColor2 : "transparent"
+                    color: (userListView.currentIndex === index) ? Theme.palette.baseColor2 : "transparent"
                 }
 
                 StatusSmartIdenticon {
@@ -379,10 +386,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     onEntered: {
-                        wrapper.hovered = true;
-                    }
-                    onExited: {
-                        wrapper.hovered = false;
+                        userListView.currentIndex = index;
                     }
                     onClicked: {
                         root.insertTag(model.name, model.publicId);


### PR DESCRIPTION
Needed for: https://github.com/status-im/status-desktop/issues/5640

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
