### PR TITLE
fix(StatusBaseInput): adjust emoji size and position in base input

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -306,6 +306,7 @@ Item {
                 root.editClicked()
             }
             RowLayout {
+                spacing: 10
                 anchors {
                     fill: parent
                     leftMargin: root.leftPadding
@@ -471,8 +472,8 @@ Item {
         StatusSmartIdenticon {
             id: identicon
 
-            icon.width: !root.icon.emoji ? 20 : 30
-            icon.height: !root.icon.emoji ? 20 : 30
+            icon.width: !root.icon.emoji ? 20 : 24
+            icon.height: !root.icon.emoji ? 20 : 24
             icon.background: root.icon.background
             icon.color: root.icon.color
             icon.letterSize: root.icon.letterSize

--- a/src/StatusQ/Core/Utils/Emoji.qml
+++ b/src/StatusQ/Core/Utils/Emoji.qml
@@ -98,7 +98,7 @@ QtObject {
         return undefined
     }
 
-    function getRandomEmoji() {
+    function getRandomEmoji(size) {
         var randomEmoji = EmojiJSON.emoji_json[Math.floor(Math.random() * EmojiJSON.emoji_json.length)]
 
         const extenstionIndex = randomEmoji.unicode.lastIndexOf('.');
@@ -115,6 +115,7 @@ QtObject {
         })
         const encodedIcon = String.fromCodePoint(...codePointParts);
 
-        return Emoji.parse(encodedIcon) + ' '
+        // Adding a space because otherwise, some emojis would fuse since emoji is just a string
+        return Emoji.parse(encodedIcon, size || undefined) + ' '
     }
 }


### PR DESCRIPTION
Makes it match the design 

![image](https://user-images.githubusercontent.com/11926403/167451857-706d6788-3a29-426b-9609-155576ad76d2.png)

Part of https://github.com/status-im/status-desktop/issues/5673

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
