### PR TITLE
improvement(StatusImageCrop): add option to limit zooming to fill mode

### DIFF
--- a/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -264,12 +264,11 @@ Item {
 
                 enabled: root.interactive
 
-                from: 1
+                from: cropEditor.minZoomScale
+                to: cropEditor.maxZoomScale
                 value: cropEditor.zoomScale
                 live: false
                 onMoved: cropEditor.setCropRect(cropEditor.getZoomRect(valueAt(visualPosition)))
-
-                to: 10
             }
             StatusIcon {
                 icon: "add-circle"


### PR DESCRIPTION
Currently, only fit-image is supported as a minimum limit

<img width="493" alt="image" src="https://user-images.githubusercontent.com/47554641/167851940-c8623fa9-2719-48c4-98bd-02ca9594c9a6.png">

This change adds the option to fill the crop window with image content as the minimum allowed zoom, which is required by the `status-go` crop function.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/47554641/167852070-d00557c1-7c95-4a0c-b068-05b54b7dbaa1.png">


### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
