### PR TITLE
fix(StatusSeedPhraseInput): ensure `doneInsertingWord` is emitted

### DIFF
--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -212,8 +212,8 @@ Item {
 
             function completeWordFill(seedWord) {
                 seedWordInput.input.edit.text = seedWord.trim();
-                // Changing the text of the input triggers the onTextChanged, thus signalling doneInsertingWord if the condition passes 
                 seedWordInput.input.edit.cursorPosition = seedWordInput.text.length;
+                root.doneInsertingWord(seedWord.trim());
             }
 
             clip: true


### PR DESCRIPTION
When `completeWorldFill()` was called, we relied on it to implicitly
emit `doneInsertingWord()` via the seed phrase input's text change
event.

However, it turns out `doneInsertingWord` is only emitted by the
component when the filtered suggestion list has one item.

In practice this isn't always the case, for example the word "fun"
might be desired, in which case the suggestion list includes "fun"
and "funny".

This introduces some third order effects, such that in Status Desktop
the view doesn't get notified that a word has been inserted, which then
causes it invalidate the mnemonic (or rather, it keeps the confirm
button disabled because it thinks there were less words inserted than
required).

To account for this we always explicitly emit the `doneInsertWord`
signal.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
