### PR TITLE
fix(StatusProgressBar): Hide text in bar if it does not fit

### DIFF
--- a/src/StatusQ/Controls/StatusProgressBar.qml
+++ b/src/StatusQ/Controls/StatusProgressBar.qml
@@ -34,10 +34,24 @@ ProgressBar {
             radius: 5
 
             StatusBaseText {
+                id: textItem
                 anchors.centerIn: parent
+                property bool _fittedInBar: width < bar.width ? true : false
                 text: control.text
                 font.pixelSize: 12
                 color: Theme.palette.indirectColor1
+                Component.onCompleted: opacity = width < bar.width ? 1 : 0
+                on_FittedInBarChanged: {
+                    if (_fittedInBar && opacity == 0) {
+                        fadeIn.start();
+                    }
+                    else if (!_fittedInBar) {
+                        fadeIn.stop();
+                        opacity = 0;
+                    }
+                }
+
+                OpacityAnimator { id: fadeIn; target: textItem; from: 0; to: 1; duration: 250 }
             }
         }
     }


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/5702

![pwd_ind-2022-05-13_11 27 06](https://user-images.githubusercontent.com/2522130/168244634-497ae08d-69a3-4d6e-a223-4a8d2bde6bcd.gif)

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
