### PR TITLE
feat(StatusTabButton): Created component as per design

### DIFF
--- a/sandbox/main.qml
+++ b/sandbox/main.qml
@@ -183,6 +183,11 @@ StatusWindow {
                             selected: viewLoader.source.toString().includes(title)
                             onClicked: mainPageView.control(title);
                         }
+                        StatusNavigationListItem {
+                            title: "StatusTabBarButton"
+                            selected: viewLoader.source.toString().includes(title)
+                            onClicked: mainPageView.page(title);
+                        }
                         StatusNavigationListItem { 
                             title: "StatusTabBarIconButton"
                             selected: viewLoader.source.toString().includes(title)

--- a/sandbox/pages/StatusTabBarButtonPage.qml
+++ b/sandbox/pages/StatusTabBarButtonPage.qml
@@ -1,0 +1,27 @@
+import QtQuick 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import Sandbox 0.1
+
+Column {
+    spacing: 8
+
+    StatusTabBar {
+        StatusTabButton {
+            width: implicitWidth
+            text: "Button 1"
+        }
+        StatusTabButton {
+            width: implicitWidth
+            text: "Button 2"
+        }
+        StatusTabButton {
+            width: implicitWidth
+            text: "Button 3"
+            badge.value: 42
+        }
+    }
+}

--- a/sandbox/qml.qrc
+++ b/sandbox/qml.qrc
@@ -42,5 +42,6 @@
         <file>pages/StatusTagSelectorPage.qml</file>
         <file>pages/StatusToastMessagePage.qml</file>
         <file>pages/StatusWizardStepperPage.qml</file>
+        <file>pages/StatusTabBarButtonPage.qml</file>
     </qresource>
 </RCC>

--- a/src/StatusQ/Controls/StatusTabBar.qml
+++ b/src/StatusQ/Controls/StatusTabBar.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.13
+
+/*!
+   \qmltype StatusTabButton
+   \inherits TabButton
+   \inqmlmodule StatusQ.Controls
+   \since StatusQ.Controls 0.1
+   \brief StatusTabBar provides a tab-based navigation model
+
+   It's customized from Qt's \l{https://doc.qt.io/qt-6/qml-qtquick-controls2-tabbar.html}{TabBar},
+   adding a transparent background.
+*/
+
+
+TabBar {
+    background: Item { }
+}

--- a/src/StatusQ/Controls/StatusTabButton.qml
+++ b/src/StatusQ/Controls/StatusTabButton.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+
+/*!
+   \qmltype StatusTabButton
+   \inherits TabButton
+   \inqmlmodule StatusQ.Controls
+   \since StatusQ.Controls 0.1
+   \brief StatusTabButton is used in conjunction with a StatusTabBar
+
+   It's customized from Qt's \l{https://doc.qt.io/qt-6/qml-qtquick-controls2-tabbutton.html}{TabButton}, adding:
+    - transparent background
+    - theme-styled text
+    - styled underscore for active state
+    - `StatusBadge` to the right from the text
+
+   An alias `badge` property is added to control the `StatusBadge` behaviour and content.
+*/
+
+TabButton {
+    id: root
+
+    property alias badge: statusBadge
+
+    leftPadding: 12
+    rightPadding: 12
+
+    background: Item { }
+
+    contentItem: Item {
+        implicitWidth: contentItemGrid.implicitWidth
+        implicitHeight: contentItemGrid.implicitHeight + 11
+
+        RowLayout {
+            id: contentItemGrid
+
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+            }
+
+            spacing: 0
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                elide: Qt.ElideRight
+                font.weight: Font.Medium
+                font.pixelSize: 15
+                color: root.checked || root.hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+                text: root.text
+            }
+
+            StatusBadge {
+                id: statusBadge
+                Layout.leftMargin: 10
+                visible: value > 0
+            }
+        }
+
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            visible: root.checked || root.hovered
+            implicitWidth: 24
+            implicitHeight: 2
+            radius: 4
+            color: root.checked ? Theme.palette.primaryColor1 : Theme.palette.primaryColor2
+        }
+    }
+}

--- a/src/StatusQ/Controls/qmldir
+++ b/src/StatusQ/Controls/qmldir
@@ -32,6 +32,8 @@ StatusPasswordStrengthIndicator 0.1 StatusPasswordStrengthIndicator.qml
 StatusSwitchTabButton 0.1 StatusSwitchTabButton.qml
 StatusSwitchTabBar 0.1 StatusSwitchTabBar.qml
 StatusSelectableText 0.1 StatusSelectableText.qml
+StatusTabBar 0.1 StatusTabBar.qml
+StatusTabButton 0.1 StatusTabButton.qml
 StatusTokenInlineSelector 0.1 StatusTokenInlineSelector.qml
 StatusWalletColorButton 0.1 StatusWalletColorButton.qml
 StatusWalletColorSelect 0.1 StatusWalletColorSelect.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -79,6 +79,7 @@
         <file>src/StatusQ/Controls/StatusSwitchTabBar.qml</file>
         <file>src/StatusQ/Controls/StatusSwitchTabButton.qml</file>
         <file>src/StatusQ/Controls/StatusTabBarIconButton.qml</file>
+        <file>src/StatusQ/Controls/StatusTabButton.qml</file>
         <file>src/StatusQ/Controls/StatusTokenInlineSelector.qml</file>
         <file>src/StatusQ/Controls/StatusToolTip.qml</file>
         <file>src/StatusQ/Controls/StatusWalletColorButton.qml</file>
@@ -10496,5 +10497,6 @@
         <file>src/assets/twemoji/svg/ae.svg</file>
         <file>src/assets/twemoji/svg/e50a.svg</file>
         <file>src/assets/twemoji/LICENSE</file>
+        <file>src/StatusQ/Controls/StatusTabBar.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Needed for status-im/status-desktop#5814

Moved the `StatusTabButton` component from the desktop app.
And improved it, so that it inherit `TabButton` properly.

Also added simple `StatusTabBar` component.

Here are screenshots of functionality:
- `Button 1` - active
- `Button 2` - hovered
- `Button 3` - with a badge

<img width="937" alt="image" src="https://user-images.githubusercontent.com/25482501/169589513-9c66ab6b-cb8d-4201-83fc-447080036464.png">
<img width="937" alt="image" src="https://user-images.githubusercontent.com/25482501/169589538-9d6634be-3376-46ee-89b2-897cd20df04d.png">

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
