### PR TITLE
fix(StatusImageCrop): fix wrong initial image fit

### DIFF
--- a/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -82,12 +82,7 @@ Item {
         \qmlproperty rect StatusImageCropPanel::cropRect
         \sa StatusImageCrop::cropRect
     */
-    property alias cropRect: cropEditor.cropRect
-    /*!
-        \qmlproperty rect StatusImageCropPanel::cropRect
-        \sa StatusImageCrop::cropRect
-    */
-    readonly property alias cropWindow: cropEditor.cropWindow
+    readonly property alias cropRect: cropEditor.cropRect
     /*!
         \qmlproperty real StatusImageCrop::scrollZoomFactor
         How fast is image scaled (zoomed) when using mouse scroll
@@ -116,16 +111,11 @@ Item {
     QtObject {
         id: d
 
+        readonly property int referenceWindowWidth: 1000
         function updateAspectRatio(newAR) {
-            // Keep width and adjust height
-            const eW = cropEditor.cropRect.width
-            const w = (eW <= 0) ? cropEditor.sourceSize.width : eW
-            const h = w/newAR
-            const c = (eW <= 0)
-                    ? Qt.point(cropEditor.sourceSize.width/2, cropEditor.sourceSize.height/2)
-                    : Qt.point(cropEditor.cropRect.x + w/2, cropEditor.cropRect.y + cropEditor.cropRect.height/2)
-            const nR = Qt.rect(c.x - w/2, c.y-h/2, w, h)
-            cropEditor.setCropRect(nR)
+            if(root.sourceSize.width === 0 || root.sourceSize.height === 0)
+                return
+            cropEditor.setCropRect(cropEditor.fillContentInWindow(root.sourceSize, Qt.size(referenceWindowWidth, referenceWindowWidth / root.aspectRatio)))
         }
     }
 


### PR DESCRIPTION
The initial fit was computed for the square crop-window

updates: 5118

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
