### PR TITLE
fix(StatusNavigationListItem): make click handler work again

### DIFF
--- a/src/StatusQ/Components/StatusNavigationListItem.qml
+++ b/src/StatusQ/Components/StatusNavigationListItem.qml
@@ -32,7 +32,7 @@ StatusListItem {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor 
         hoverEnabled: true
-        onClicked: statusNavigationListItem.clicked(mouse)
+        onClicked: statusNavigationListItem.clicked(statusNavigationListItem.itemId, mouse)
     }
 
     components: [


### PR DESCRIPTION
The click handler used inside the component broke in one of the latest
changes done in `StatusListItem` where it expects two arguments being
passed to its click handler.

This commit fixes it by supplying all needed arguments (where `itemId`
is always `''` unless set differently)