### PR TITLE
feat(Theme): Added `radius` and `bigPadding` properties

### DIFF
--- a/src/StatusQ/Core/Theme/Theme.qml
+++ b/src/StatusQ/Core/Theme/Theme.qml
@@ -6,6 +6,9 @@ QtObject {
     id: appTheme
     property QtObject palette: StatusLightTheme {}
 
+    property int bigPadding: 24
+    property int radius: 8
+
     function setTheme(theme) {
         palette = theme
     }


### PR DESCRIPTION
We use `Style.current.bigPadding` kind of properties for sizing in status-desktop.
As I understand, we have deprecated the `Style` component in favor of StatusQ `Theme`.
If so, StatusQ `Theme` should also contain sizing properties.

I've only added `raidus` and `bigPadding`, which I used implementing https://github.com/status-im/status-desktop/issues/5814.

If all other sizing properties should also be moved here, I can do that.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
