### PR TITLE
fix(StatusSearchPopup): add color hash to chat icons

### DIFF
--- a/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -103,7 +103,9 @@ StatusPopupMenu {
                         text: model.text
                         image.source: model.imageSource
                         iconSettings.name: model.iconName
-                        iconSettings.color: model.iconColor
+                        iconSettings.color: model.isUserIcon ? Theme.palette.userCustomizationColors[model.colorId] : model.iconColor
+                        iconSettings.charactersLen: model.isUserIcon ? 2 : 1
+                        ringSettings.ringSpecModel: model.colorHash
                         onTriggered: {
                             searchPopup.resetSearchSelection()
                             if (menuLoader.parentTitleText === "Chat") {
@@ -112,7 +114,10 @@ StatusPopupMenu {
                                                                model.imageSource,
                                                                model.isIdenticon,
                                                                model.iconName,
-                                                               model.iconColor)
+                                                               model.iconColor,
+                                                               model.isUserIcon,
+                                                               model.colorId,
+                                                               model.colorHash.toJson())
                             } else {
                                 searchPopup.setSearchSelection(menuLoader.parentTitleText,
                                                    model.text,

--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -40,14 +40,19 @@ StatusModal {
                                 imageSource = "",
                                 isIdenticon = "",
                                 iconName = "",
-                                iconColor = "") {
+                                iconColor = "",
+                                isUserIcon = false,
+                                colorId = 0,
+                                colorHash = "") {
         searchSelectionButton.primaryText = text
         searchSelectionButton.secondaryText = secondaryText
         searchSelectionButton.image.source = imageSource
         searchSelectionButton.image.isIdenticon = isIdenticon
         searchSelectionButton.iconSettings.name = iconName
-        searchSelectionButton.iconSettings.color = iconColor !== ""? iconColor : Theme.palette.primaryColor1
+        searchSelectionButton.iconSettings.color = isUserIcon ? Theme.palette.userCustomizationColors[colorId] : iconColor
         searchSelectionButton.iconSettings.isLetterIdenticon = !iconName && !imageSource
+        searchSelectionButton.iconSettings.charactersLen = isUserIcon ? 2 : 1
+        searchSelectionButton.ringSettings.ringSpecModel = !!colorHash ? JSON.parse(colorHash) : {}
     }
 
     function resetSearchSelection() {
@@ -129,7 +134,7 @@ StatusModal {
                         height: 16
                         name: ""
                         isLetterIdenticon: false
-                        letterSize: 11
+                        letterSize: charactersLen > 1 ? 8 : 11
                     }
 
                     property StatusImageSettings image: StatusImageSettings {
@@ -138,6 +143,8 @@ StatusModal {
                         source: ""
                         isIdenticon: false
                     }
+
+                    property alias ringSettings: identicon.ringSettings
 
                     anchors.left: parent.left
                     anchors.leftMargin: 16
@@ -270,7 +277,8 @@ StatusModal {
                         statusListItemSubTitle.elide: Text.ElideRight
                         statusListItemSubTitle.color: Theme.palette.directColor1
                         icon.isLetterIdenticon: (model.image === "")
-                        icon.background.color: model.color
+                        icon.color: model.isUserIcon ? Theme.palette.userCustomizationColors[model.colorId] : model.color
+                        icon.charactersLen: model.isUserIcon ? 2 : 1
                         titleAsideText: root.formatTimestampFn(model.time)
                         image.source: model.image
                         badge.primaryText: model.badgePrimaryText
@@ -278,6 +286,7 @@ StatusModal {
                         badge.image.source: model.badgeImage
                         badge.icon.isLetterIdenticon: model.badgeIsLetterIdenticon
                         badge.icon.color: model.badgeIconColor
+                        ringSettings.ringSpecModel: model.colorHash
 
                         onClicked: {
                             root.resultItemClicked(itemId)

--- a/src/StatusQ/Popups/StatusSearchPopupMenuItem.qml
+++ b/src/StatusQ/Popups/StatusSearchPopupMenuItem.qml
@@ -16,6 +16,7 @@ MenuItem {
         width: 16
         isIdenticon: false
     }
+
     property StatusIconSettings iconSettings: StatusIconSettings {
         height: 16
         width: 16
@@ -23,8 +24,10 @@ MenuItem {
                             && root.iconSettings.name.toString() === "")
         background: StatusIconBackgroundSettings {}
         color: (name === "channel") ? Theme.palette.directColor1 : "transparent"
-        letterSize: 11
+        letterSize: charactersLen > 1 ? 8 : 11
     }
+
+    property alias ringSettings: identicon.ringSettings
 
     background: Rectangle {
         color: root.hovered ? Theme.palette.statusPopupMenu.hoverBackgroundColor : "transparent"
@@ -43,6 +46,7 @@ MenuItem {
                 image: root.image
                 icon: root.iconSettings
                 name: root.text
+                ringSettings: root.ringSettings
             }
         }
         StatusBaseText {


### PR DESCRIPTION
needed by: https://github.com/status-im/status-desktop/pull/5940

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
