### PR TITLE
feat(StatusTagSelector): Added colorIdForPubkeyGetter property

### DIFF
--- a/sandbox/demoapp/CreateChatView.qml
+++ b/sandbox/demoapp/CreateChatView.qml
@@ -58,6 +58,11 @@ Page {
                 }
                 return randomString.join().toString().replace(/,/g, '');
             }
+            colorIdForPubkeyGetter: function (pubKey) {
+                //for simulation purposes only, in real app
+                //this would be Utils.colorIdForPubkey(pubKey);
+                return Math.floor(Math.random() * 10);
+            }
             onTextChanged: {
                 sortModel(root.contactsModel);
             }

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -96,18 +96,25 @@ Item {
     property int nameCountLimit: 5
 
     /*!
-        \qmlproperty var StatusTagSelector::ringSpecModel
+        \qmlproperty var StatusTagSelector::ringSpecModelGetter
         This property holds the function to calculate the ring spec model
         based on the public key.
     */
     property var ringSpecModelGetter: (pubKey) => { /*return ringSpecModel*/ }
 
     /*!
-        \qmlproperty var StatusTagSelector::compressKey
+        \qmlproperty var StatusTagSelector::compressKeyGetter
         This property holds the function to calculate the compressed
         key based on the public key.
     */
     property var compressedKeyGetter: (pubKey) => { /*return compressed key;*/ }
+
+    /*!
+        \qmlproperty var StatusTagSelector::colorIdForPubkeyGetter
+        This property holds the function to calculate the color Id
+        based on the public key.
+    */
+    property var colorIdForPubkeyGetter: (pubKey) => { /*return color Id;*/ }
 
     /*!
         \qmlproperty ListModel StatusTagSelector::sortedList
@@ -390,6 +397,7 @@ Item {
                 isMutualContact: model.isMutualContact
                 image.source: model.icon
                 image.isIdenticon: model.isIdenticon
+                icon.color: Theme.palette.userCustomizationColors[root.colorIdForPubkeyGetter(model.publicId)]
                 isOnline: model.onlineStatus
                 statusListItemIcon.badge.border.color: sensor.containsMouse ? Theme.palette.baseColor2 : Theme.palette.baseColor4
                 ringSettings.ringSpecModel: root.ringSpecModelGetter(publicId)


### PR DESCRIPTION
Needed for: https://github.com/status-im/status-desktop/issues/5875

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
