### PR TITLE
feat(StatusTagSelector): Introduced readonly tags and possibility of icon

### DIFF
--- a/sandbox/controls/Layout.qml
+++ b/sandbox/controls/Layout.qml
@@ -83,6 +83,8 @@ Column {
                         icon: ""
                         isIdenticon: false
                         onlineStatus: 3
+                        isReadonly: true
+                        tagIcon: "crown"
                     }
                     ListElement {
                         publicId: "0x1"
@@ -90,6 +92,8 @@ Column {
                         icon: ""
                         isIdenticon: false
                         onlineStatus: 1
+                        isReadonly: false
+                        tagIcon: ""
                     }
                 }
                 toLabelText: qsTr("To: ")

--- a/sandbox/demoapp/data/Models.qml
+++ b/sandbox/demoapp/data/Models.qml
@@ -852,6 +852,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
                             nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
             isIdenticon: true
+            isAdmin: false
             ringSpecModel: [ ListElement {colorId: 13; segmentLength: 5},
                              ListElement {colorId: 31; segmentLength: 5},
                              ListElement {colorId: 10; segmentLength: 1},
@@ -868,6 +869,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             isMutualContact: false
             onlineStatus: false
             icon: ""
+            isAdmin: false
             isIdenticon: false            
         }
         ListElement {
@@ -877,6 +879,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             trustIndicator: StatusContactVerificationIcons.TrustedType.None
             isMutualContact: false
             onlineStatus: true
+            isAdmin: false
             icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAiElEQVR4nOzXUQpAQBRGYWQvLNAyLJDV8C5qpiGnv/M9al5Ot27X0IUwhMYQGkNoDKGJCRlLH67bftx9X+ap/+P9VcxEDK
                      ExhKZ4a9Uq3TZviZmIITSG0DRvlqcbqVbrlouZiCE0htD4h0hjCI0hNN5aNIbQGKKPxEzEEBpDaAyhMYTmDAAA//+gYCErzmCpCQAAAABJRU5ErkJggg=="
             isIdenticon: true
@@ -897,6 +900,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             onlineStatus: false
             icon: ""
             isIdenticon: false
+            isAdmin: false
             ringSpecModel: [ ListElement {colorId: 0; segmentLength: 1},
                              ListElement {colorId: 28; segmentLength: 1},
                              ListElement {colorId: 31; segmentLength: 1},

--- a/sandbox/pages/StatusTagSelectorPage.qml
+++ b/sandbox/pages/StatusTagSelectorPage.qml
@@ -9,17 +9,21 @@ Item {
     property ListModel asortedContacts: ListModel {
         ListElement {
             publicId: "0x0"
-            name: "Maria"
+            name: "emily.eth"
             icon: ""
             isIdenticon: false
             onlineStatus: 3
+            isReadonly: false
+            tagIcon: ""
         }
         ListElement {
             publicId: "0x1"
-            name: "James"
+            name: "vitalikbuterin"
             icon: "https://pbs.twimg.com/profile_images/1369221718338895873/T_5fny6o_400x400.jpg"
             isIdenticon: false
             onlineStatus: 1
+            isReadonly: false
+            tagIcon: ""
         }
         ListElement {
             publicId: "0x2"
@@ -27,13 +31,17 @@ Item {
             icon: ""
             isIdenticon: false
             onlineStatus: 2
+            isReadonly: false
+            tagIcon: ""
         }
         ListElement {
             publicId: "0x3"
-            name: "Tracy"
+            name: "carmen.eth"
             icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
             isIdenticon: true
             onlineStatus: 3
+            isReadonly: true
+            tagIcon: "crown"
         }
         ListElement {
             publicId: "0x4"
@@ -41,6 +49,8 @@ Item {
             icon: ""
             isIdenticon: false
             onlineStatus: 3
+            isReadonly: false
+            tagIcon: ""
         }
     }
 

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
 
 /*!
      \qmltype StatusTagSelector
@@ -276,69 +277,14 @@ Item {
                     }
                     onWidthChanged: { scrollToEnd(); }
                     onCountChanged: { scrollToEnd(); }
-                    delegate: Rectangle {
-                        id: nameDelegate
+                    delegate: StatusTagItem {
+                        isReadonly: model.isReadonly
+                        text: model.name
+                        icon: model.tagIcon
 
-                        property int tagMargins: 8
-                        property int tagIconsSize: 20
-                        function getTagColor(isReadonly) {
-                            if(isReadonly) {
-                                return Theme.palette.baseColor1
-                            }
-                            else {
-                                return mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
-                            }
-                        }
-
-                        width: tagRow.implicitWidth + 2 * nameDelegate.tagMargins
-                        height: 30
-                        color: getTagColor(model.isReadonly)
-                        radius: 8
-                        Row {
-                            id: tagRow
-                            height: parent.height
-                            anchors.left: parent.left
-                            anchors.leftMargin: nameDelegate.tagMargins
-                            anchors.rightMargin: nameDelegate.tagMargins
-                            spacing: 2
-
-                            StatusIcon {
-                                visible: model.tagIcon
-                                anchors.verticalCenter: parent.verticalCenter
-                                color: Theme.palette.indirectColor1
-                                width: model.tagIcon ? nameDelegate.tagIconsSize : 0
-                                height: nameDelegate.tagIconsSize
-                                icon: model.tagIcon
-                            }
-                            StatusBaseText {
-                                id: nameText
-                                anchors.verticalCenter: parent.verticalCenter
-                                color: Theme.palette.indirectColor1
-                                font.pixelSize: 15
-                                text: name
-                            }
-                            StatusIcon {
-                                id: closeIcon
-                                visible: !model.isReadonly
-                                anchors.leftMargin: nameDelegate.tagMargins
-                                anchors.verticalCenter: parent.verticalCenter
-                                color: Theme.palette.indirectColor1
-                                width: nameDelegate.tagIconsSize
-                                height: nameDelegate.tagIconsSize
-                                icon: "close"
-                            }
-                        }
-
-                        MouseArea {
-                            id: mouseArea
-                            enabled: !model.isReadonly
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                            onClicked: {
-                                removeMember(publicId);
-                                namesModel.remove(index, 1);
-                            }
+                        onClicked: {
+                            removeMember(model.publicId);
+                            namesModel.remove(index, 1);
                         }
                     }
                 }

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -132,6 +132,12 @@ Item {
         By default is set to false.
     */
     property bool showSortedListOnlyWhenText: false
+    /*!
+        \qmlproperty bool StatusTagSelector::orderByReadonly
+        This property will decide if the displayed tag names will be ordered from left to right starting with the items that are marked as `isReadonly`.
+        By default is set to true (readonly names at left).
+    */
+    property bool orderByReadonly: true
 
     /*!
         \qmlmethod
@@ -146,9 +152,12 @@ Item {
         \qmlmethod
         This function is used to insert a new tag.
     */
-    function insertTag(name, id) {
+    function insertTag(name, id, isReadonly, tagIcon) {
         if (!find(namesModel, function(item) { return item.publicId === id }) && namesModel.count < root.nameCountLimit) {
-            namesModel.insert(namesModel.count, {"name": name, "publicId": id});
+            if(orderByReadonly && isReadonly)
+                namesModel.insert(0, {"name": name, "publicId": id, "isReadonly": !!isReadonly, "tagIcon": tagIcon ? tagIcon : ""});
+            else
+                namesModel.insert(namesModel.count, {"name": name, "publicId": id, "isReadonly": !!isReadonly, "tagIcon": tagIcon ? tagIcon : ""});
             addMember(id);
             edit.clear();
         }
@@ -165,11 +174,17 @@ Item {
                 var entry = inputModel.get(i);
                 if (entry.name.toLowerCase().includes(text.toLowerCase()) &&
                     !find(namesModel, function(item) { return item.name === entry.name })) {
-                    sortedList.append({"publicId": entry.publicId, "name": entry.name,
-                                       "nickName": entry.nickName, "trustIndicator": entry.trustIndicator,
-                                       "isMutualContact": entry.isMutualContact, "ringSpecModel": entry.ringSpecModel,
-                                       "icon": entry.icon, "isIdenticon": entry.isIdenticon,
-                                       "onlineStatus": entry.onlineStatus});
+                    sortedList.append({"publicId": entry.publicId,
+                                       "name": entry.name,
+                                       "nickName": entry.nickName,
+                                       "trustIndicator": entry.trustIndicator,
+                                       "isMutualContact": entry.isMutualContact,
+                                       "ringSpecModel": entry.ringSpecModel,
+                                       "icon": entry.icon,
+                                       "isIdenticon": entry.isIdenticon,
+                                       "onlineStatus": entry.onlineStatus,
+                                       "tagIcon": entry.tagIcon ? entry.tagIcon : "",
+                                       "isReadonly": !!entry.isReadonly});
                     userListView.model = sortedList;
                 }
             }
@@ -198,10 +213,27 @@ Item {
                                                                                 2 * bgRect.anchors.margins +
                                                                                 userListView.anchors.topMargin + userListView.anchors.bottomMargin +
                                                                                 (userListView.model.count * 64): 0
+
+        function orderNamesModel() {
+            if(root.orderByReadonly) {
+                for(var i = 0; i < namesModel.count; i++) {
+                    var entry = namesModel.get(i)
+                    if(entry.isReadonly) {
+                        namesModel.move(i, 0, 1)
+                    }
+                }
+            }
+        }
     }
 
     implicitWidth: 448
     implicitHeight: (tagSelectorRect.height + d.suggestionContainerHeight) > root.maxHeight ? root.maxHeight : (tagSelectorRect.height + d.suggestionContainerHeight)
+
+    onOrderByReadonlyChanged: { d.orderNamesModel() }
+    Component.onCompleted: {
+        // Component initialization:
+        d.orderNamesModel()
+    }
 
     Rectangle {
         id: tagSelectorRect
@@ -246,29 +278,63 @@ Item {
                     onCountChanged: { scrollToEnd(); }
                     delegate: Rectangle {
                         id: nameDelegate
-                        width: (nameText.contentWidth + 34)
+
+                        property int tagMargins: 8
+                        property int tagIconsSize: 20
+                        function getTagColor(isReadonly) {
+                            if(isReadonly) {
+                                return Theme.palette.baseColor1
+                            }
+                            else {
+                                return mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
+                            }
+                        }
+
+                        width: tagRow.implicitWidth + 2 * nameDelegate.tagMargins
                         height: 30
-                        color: mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
+                        color: getTagColor(model.isReadonly)
                         radius: 8
-                        StatusBaseText {
-                            id: nameText
+                        Row {
+                            id: tagRow
+                            height: parent.height
                             anchors.left: parent.left
-                            anchors.leftMargin: 8
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: Theme.palette.indirectColor1
-                            text: name
+                            anchors.leftMargin: nameDelegate.tagMargins
+                            anchors.rightMargin: nameDelegate.tagMargins
+                            spacing: 2
+
+                            StatusIcon {
+                                visible: model.tagIcon
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: Theme.palette.indirectColor1
+                                width: model.tagIcon ? nameDelegate.tagIconsSize : 0
+                                height: nameDelegate.tagIconsSize
+                                icon: model.tagIcon
+                            }
+                            StatusBaseText {
+                                id: nameText
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: Theme.palette.indirectColor1
+                                font.pixelSize: 15
+                                text: name
+                            }
+                            StatusIcon {
+                                id: closeIcon
+                                visible: !model.isReadonly
+                                anchors.leftMargin: nameDelegate.tagMargins
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: Theme.palette.indirectColor1
+                                width: nameDelegate.tagIconsSize
+                                height: nameDelegate.tagIconsSize
+                                icon: "close"
+                            }
                         }
-                        StatusIcon {
-                            anchors.left: nameText.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: Theme.palette.indirectColor1
-                            icon: "close"
-                        }
+
                         MouseArea {
                             id: mouseArea
+                            enabled: !model.isReadonly
                             anchors.fill: parent
                             hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
+                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                             onClicked: {
                                 removeMember(publicId);
                                 namesModel.remove(index, 1);
@@ -297,8 +363,11 @@ Item {
                         namesModel.remove((namesList.count-1), 1);
                     }
                     if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && (sortedList.count > 0)) {
-                        root.insertTag(sortedList.get(userListView.currentIndex).name, sortedList.get(userListView.currentIndex).publicId);
-                    }
+                        root.insertTag(sortedList.get(userListView.currentIndex).name,
+                                       sortedList.get(userListView.currentIndex).publicId,
+                                       sortedList.get(userListView.currentIndex).isReadonly,
+                                       sortedList.get(userListView.currentIndex).tagIcon);
+                    }                    
                 }
                 Keys.onUpPressed: { userListView.decrementCurrentIndex(); }
                 Keys.onDownPressed: { userListView.incrementCurrentIndex(); }
@@ -403,7 +472,7 @@ Item {
                 ringSettings.ringSpecModel: root.ringSpecModelGetter(publicId)
                 color: (sensor.containsMouse || highlighted) ? Theme.palette.baseColor2 : "transparent"
                 onClicked: {
-                    root.insertTag(model.name, model.publicId);
+                    root.insertTag(model.name, model.publicId, model.isAdmin, model.isAdmin ? "crown" : "");
                 }
             }
         }

--- a/src/StatusQ/Controls/StatusTagItem.qml
+++ b/src/StatusQ/Controls/StatusTagItem.qml
@@ -1,0 +1,116 @@
+import QtQuick 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+/*!
+     \qmltype StatusTagItem
+     \inherits Item
+     \inqmlmodule StatusQ.Controls
+     \since StatusQ.Controls 0.1
+     \brief Reprsents a tag item.
+     Inherits \l{https://doc.qt.io/qt-5/qml-qtquick-rectangle.html}{Item}.
+
+     The \c StatusTagItem represents a tag item where a name and icon can be displayed and can be clicked.
+     Example:
+
+     \qml
+        StatusTagItem {
+            isReadonly: model.isReadonly
+            text: model.name
+            icon: model.tagIcon
+
+            onClicked: { console.log("Tag selected!") }
+        }
+     \endqml
+
+     For a list of components available see StatusQ.
+  */
+Rectangle {
+    id: root
+
+    /*!
+        \qmlproperty bool StatusTagItem::isReadonly
+        This property sets if the tag is readonly or not.
+    */
+    property bool isReadonly
+    /*!
+        \qmlproperty string StatusTagItem::name
+        This property sets the tag text to display.
+    */
+    property string text
+    /*!
+        \qmlproperty string StatusTagItem::icon
+        This property sets the tag icon to display.
+    */
+    property string icon
+
+    /*!
+        \qmlsignal
+        This signal is emitted when the tag is clicked.
+    */
+    signal clicked()
+
+    QtObject {
+        id: d
+        property int tagMargins: 8
+        property int tagIconsSize: 20
+
+        function getTagColor(isReadonly) {
+            if(isReadonly) {
+                return Theme.palette.baseColor1
+            }
+            else {
+                return mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
+            }
+        }
+    }
+
+    width: tagRow.implicitWidth + 2 * d.tagMargins
+    height: 30
+    color: d.getTagColor(root.isReadonly)
+    radius: 8
+    Row {
+        id: tagRow
+        height: parent.height
+        anchors.left: parent.left
+        anchors.leftMargin: d.tagMargins
+        anchors.rightMargin: d.tagMargins
+        spacing: 2
+
+        StatusIcon {
+            visible: root.icon
+            anchors.verticalCenter: parent.verticalCenter
+            color: Theme.palette.indirectColor1
+            width: root.icon ? d.tagIconsSize : 0
+            height: d.tagIconsSize
+            icon: root.icon
+        }
+        StatusBaseText {
+            id: nameText
+            anchors.verticalCenter: parent.verticalCenter
+            color: Theme.palette.indirectColor1
+            font.pixelSize: 15
+            text: root.text
+        }
+        StatusIcon {
+            id: closeIcon
+            visible: !root.isReadonly
+            anchors.leftMargin: d.tagMargins
+            anchors.verticalCenter: parent.verticalCenter
+            color: Theme.palette.indirectColor1
+            width: d.tagIconsSize
+            height: d.tagIconsSize
+            icon: "close"
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        enabled: !root.isReadonly
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: { root.clicked() }
+    }
+}

--- a/src/StatusQ/Controls/qmldir
+++ b/src/StatusQ/Controls/qmldir
@@ -35,6 +35,7 @@ StatusSwitchTabBar 0.1 StatusSwitchTabBar.qml
 StatusSelectableText 0.1 StatusSelectableText.qml
 StatusTabBar 0.1 StatusTabBar.qml
 StatusTabButton 0.1 StatusTabButton.qml
+StatusTagItem 0.1 StatusTagItem.qml
 StatusTokenInlineSelector 0.1 StatusTokenInlineSelector.qml
 StatusWalletColorButton 0.1 StatusWalletColorButton.qml
 StatusWalletColorSelect 0.1 StatusWalletColorSelect.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -10501,5 +10501,6 @@
         <file>src/assets/twemoji/svg/e50a.svg</file>
         <file>src/assets/twemoji/LICENSE</file>
         <file>src/StatusQ/Controls/StatusTabBar.qml</file>
+        <file>src/StatusQ/Controls/StatusTagItem.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Closes #694

### What does the PR do

- Different tag color depending if the entry `isReadonly` or not.
- Tag disabled if the entry `isReadonly`.
- Possibility to show icon if entry contains the proper info.
- Added property `orderByReadonly` to position `isReadonly` entries in the left.

Updated sandbox project examples according to new tag updates.

### Affected areas
Layouts / StatusTagsSelector
StatusTagsSelectorPage
demoApp/CreateChat

### Screenshot of functionality
https://user-images.githubusercontent.com/97019400/171397952-d971fdb3-a855-40f5-a3bf-5b405620987b.mov

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
