### PR TITLE
chore: adapt to new user/member backend models structure

### DIFF
--- a/src/StatusQ/Components/StatusMemberListItem.qml
+++ b/src/StatusQ/Components/StatusMemberListItem.qml
@@ -48,30 +48,35 @@ StatusListItem {
     */
     property string userName: ""
     /*!
-       \qmlproperty string StatusMemberListItem::chatKey
-       This property holds the chat key of the member represented.
+       \qmlproperty string StatusMemberListItem::pubKey
+       This property holds the chat public key of the member represented.
     */
-    property string chatKey: ""
+    property string pubKey: ""
     /*!
-       \qmlproperty string StatusMemberListItem::isMutualContact
-       This property holds if the member represented is a mutual contact.
+       \qmlproperty string StatusMemberListItem::isContact
+       This property holds if the member represented is contact.
     */
-    property bool isMutualContact: false
+    property bool isContact: false
     /*!
-       \qmlproperty string StatusMemberListItem::trustIndicator
-       This property holds the trust indicator of the member represented. Possible values are:
-       \list
-       \li StatusContactVerificationIcons.TrustedType.None
-       \li StatusContactVerificationIcons.TrustedType.Verified
-       \li StatusContactVerificationIcons.TrustedType.Untrustworthy
-       \endlist
+       \qmlproperty string StatusMemberListItem::isVerified
+       This property holds if the member represented is verified contact.
     */
-    property var trustIndicator: StatusContactVerificationIcons.TrustedType.None
+    property bool isVerified: false
     /*!
-       \qmlproperty string StatusMemberListItem::isOnline
+       \qmlproperty string StatusMemberListItem::isUntrustworthy
+       This property holds if the member represented is untrustworthy.
+    */
+    property bool isUntrustworthy: false
+    /*!
+       \qmlproperty string StatusMemberListItem::status
        This property holds the connectivity status of the member represented.
+       0 - offline
+       1 - online
+       2 - doNotDisturb
+       3 - idle
     */
-    property bool isOnline: false
+    // FIXME: move Constants.userStatus from status-desktop
+    property int status: 0
     /*!
        \qmlproperty string StatusMemberListItem::isAdmin
        This property holds the admin status of the member represented.
@@ -87,33 +92,37 @@ StatusListItem {
             if(root.userName !== "" && root.nickName !== "")
                 compose = "(" + root.userName + ")"
 
-            if(compose !== "" && root.chatKey !== "")
+            if(compose !== "" && root.pubKey !== "")
                 // Composition
-                compose += " • " + composeShortKeyChat(root.chatKey)
+                compose += " • " + composeShortKeyChat(root.pubKey)
 
-            else if(root.chatKey !== "")
-                compose = composeShortKeyChat(root.chatKey)
+            else if(root.pubKey !== "")
+                compose = composeShortKeyChat(root.pubKey)
 
             return compose
         }
 
         // Short keychat composition:
-        function composeShortKeyChat(chatKey) {
-            return chatKey.substring(0, 5) + "..." + chatKey.substring(chatKey.length - 3)
+        function composeShortKeyChat(pubKey) {
+            return pubKey.substring(0, 5) + "..." + pubKey.substring(pubKey.length - 3)
         }
     }
 
     // root object settings:
     title: (root.nickName === "") ? root.userName : root.nickName
     statusListItemTitleIcons.sourceComponent: StatusContactVerificationIcons {
-        isMutualContact: root.isMutualContact
-        trustIndicator: root.trustIndicator
+        isMutualContact: root.isContact
+        trustIndicator: {
+            if (root.isVerified) return StatusContactVerificationIcons.TrustedType.Verified
+            else if (root.isUntrustworthy) return StatusContactVerificationIcons.TrustedType.Untrustworthy
+            return StatusContactVerificationIcons.TrustedType.None
+        } 
     }
     subTitle: d.composeSubtitile()
     statusListItemSubTitle.font.pixelSize: 10
     icon.isLetterIdenticon: !root.image.source.toString()
     statusListItemIcon.badge.visible: true
-    statusListItemIcon.badge.color: root.isOnline ? Theme.palette.successColor1 : Theme.palette.baseColor1
+    statusListItemIcon.badge.color: root.status === 1 ? Theme.palette.successColor1 : Theme.palette.baseColor1 // FIXME
     color: sensor.containsMouse ? Theme.palette.baseColor2 : Theme.palette.baseColor4
 
     // Default sizes / positions by design

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -409,13 +409,14 @@ Item {
                 }
                 nickName: model.nickName
                 userName: model.name
-                chatKey: root.compressedKeyGetter(model.publicId)
-                trustIndicator: model.trustIndicator
-                isMutualContact: model.isMutualContact
+                pubKey: root.compressedKeyGetter(model.publicId)
+                isVerified: false // FIXME
+                isUntrustworthy: false // FIXME
+                isContact: model.isMutualContact
                 image.source: model.icon
                 image.isIdenticon: model.isIdenticon
                 icon.color: Theme.palette.userCustomizationColors[root.colorIdForPubkeyGetter(model.publicId)]
-                isOnline: model.onlineStatus
+                status: model.onlineStatus
                 statusListItemIcon.badge.border.color: sensor.containsMouse ? Theme.palette.baseColor2 : Theme.palette.baseColor4
                 ringSettings.ringSpecModel: root.ringSpecModelGetter(publicId)
                 color: (sensor.containsMouse || highlighted) ? Theme.palette.baseColor2 : "transparent"


### PR DESCRIPTION
### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
