### PR TITLE
chore(StatusModal): make StatusModal follow padding

### DIFF
--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -194,10 +194,11 @@ QC.Popup {
 
     width: 480
 
-    topPadding: headerImpl.implicitHeight
-    bottomPadding: footerImpl.implicitHeight
-    leftPadding: 0
-    rightPadding: 0
+    padding: 0
+    topPadding: padding + headerImpl.implicitHeight
+    bottomPadding: padding + footerImpl.implicitHeight
+    leftPadding: padding
+    rightPadding: padding
 
     modal: true
 

--- a/src/StatusQ/Popups/StatusModal.qml
+++ b/src/StatusQ/Popups/StatusModal.qml
@@ -200,6 +200,8 @@ QC.Popup {
     leftPadding: padding
     rightPadding: padding
 
+    margins: 64
+
     modal: true
 
     QC.Overlay.modal: Rectangle {


### PR DESCRIPTION
https://github.com/status-im/status-desktop/pull/6010#discussion_r892148627

Still, the solution is not perfect, because there is no ability to set the top and bottom padding in a convenient way, see point 1 from https://github.com/status-im/status-desktop/issues/7556

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
