### PR TITLE
fix(StatusTabButton): Hide bottom dash in disabled state

### DIFF
--- a/src/StatusQ/Controls/StatusTabButton.qml
+++ b/src/StatusQ/Controls/StatusTabButton.qml
@@ -66,7 +66,7 @@ TabButton {
         Rectangle {
             anchors.bottom: parent.bottom
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: root.checked || root.hovered
+            visible: root.enabled && (root.checked || root.hovered)
             implicitWidth: 24
             implicitHeight: 2
             radius: 4


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/pull/5920

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
