### PR TITLE
fix(Theme): Updated `userCustomizationColors` list per designs

### DIFF
--- a/src/StatusQ/Controls/StatusColorSelectorGrid.qml
+++ b/src/StatusQ/Controls/StatusColorSelectorGrid.qml
@@ -14,18 +14,7 @@ Column {
 
     property int selectedColorIndex: 0
     property string selectedColor: ""
-    property var model:[ StatusColors.colors['black'],
-                         StatusColors.colors['grey'],
-                         StatusColors.colors['blue2'],
-                         StatusColors.colors['purple'],
-                         StatusColors.colors['cyan'],
-                         StatusColors.colors['violet'],
-                         StatusColors.colors['red2'],
-                         StatusColors.colors['yellow'],
-                         StatusColors.colors['green2'],
-                         StatusColors.colors['moss'],
-                         StatusColors.colors['brown'],
-                         StatusColors.colors['brown2'] ]
+    property var model: Theme.palette.userCustomizationColors
 
     signal colorSelected(color color)
 
@@ -43,6 +32,7 @@ Column {
         columns: 6
         rowSpacing: 16
         columnSpacing: 32
+
         Repeater {
             model: root.model
             delegate: StatusColorRadioButton {

--- a/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -147,21 +147,6 @@ ThemePalette {
     miscColor11: getColor('yellow2')
     miscColor12: getColor('green6')
 
-    userCustomizationColors: [
-        "#AAC6FF",
-        "#887AF9",
-        "#51D0F0",
-        "#D37EF4",
-        "#FA6565",
-        "#FFCA0F",
-        "#93DB33",
-        "#10A88E",
-        "#AD4343",
-        "#EAD27B",
-        "silver", // update me when figma is ready
-        "darkgrey", // update me when figma is ready
-    ]
-
     identiconRingColors: ["#000000", "#726F6F", "#C4C4C4", "#E7E7E7", "#FFFFFF", "#00FF00",
                           "#009800", "#B8FFBB", "#FFC413", "#9F5947", "#FFFF00", "#A8AC00",
                           "#FFFFB0", "#FF5733", "#FF0000", "#9A0000", "#FF9D9D", "#FF0099",

--- a/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -145,21 +145,6 @@ ThemePalette {
     miscColor11: getColor('brown2')
     miscColor12: getColor('green5')
 
-    userCustomizationColors: [
-        "#2946C4",
-        "#887AF9",
-        "#51D0F0",
-        "#D37EF4",
-        "#FA6565",
-        "#FFCA0F",
-        "#7CDA00",
-        "#26A69A",
-        "#8B3131",
-        "#9B832F",
-        "silver", // update me when figma is ready
-        "darkgrey", // update me when figma is ready
-    ]
-
     identiconRingColors: ["#000000", "#726F6F", "#C4C4C4", "#E7E7E7", "#FFFFFF", "#00FF00",
                           "#009800", "#B8FFBB", "#FFC413", "#9F5947", "#FFFF00", "#A8AC00",
                           "#FFFFB0", "#FF5733", "#FF0000", "#9A0000", "#FF9D9D", "#FF0099",

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -90,7 +90,20 @@ QtObject {
     property color miscColor11
     property color miscColor12
 
-    property var userCustomizationColors: []
+    property var userCustomizationColors: [
+        getColor('black', 0.8),
+        getColor('grey'),
+        getColor('blue2'),
+        getColor('purple'),
+        getColor('cyan'),
+        getColor('violet'),
+        getColor('red2'),
+        getColor('yellow'),
+        getColor('green2'),
+        getColor('moss'),
+        getColor('brown'),
+        getColor('brown2'),
+    ]
 
     property var identiconRingColors: []
 


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/issues/5837

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
