### PR TITLE
fix(StatusColrSelectorGrid): Fixed buttons size and  `userCustomizationColors` list

### DIFF
--- a/src/StatusQ/Controls/StatusColorRadioButton.qml
+++ b/src/StatusQ/Controls/StatusColorRadioButton.qml
@@ -8,11 +8,13 @@ RadioButton {
 
     property string radioButtonColor: ""
     property string selectionColor: StatusColors.colors['white']
-    property int diameter: 48
-    property int selectorDiameter: 20
+    property int diameter: 44
+    property int selectorDiameter: 16
 
-    implicitWidth: 48
-    implicitHeight: 48
+    spacing: 0
+
+    implicitWidth: 44
+    implicitHeight: 44
 
     indicator: Rectangle {
         implicitWidth: control.diameter
@@ -21,13 +23,13 @@ RadioButton {
         color: radioButtonColor
 
         Rectangle {
+            anchors.centerIn: parent
             width: control.selectorDiameter
             height: control.selectorDiameter
+            visible: control.checked
             radius: width/2
             color: selectionColor
             border.color: StatusColors.colors['grey3']
-            visible: control.checked
-            anchors.centerIn: parent
         }
     }
 }

--- a/src/StatusQ/Controls/StatusColorSelectorGrid.qml
+++ b/src/StatusQ/Controls/StatusColorSelectorGrid.qml
@@ -36,6 +36,7 @@ Column {
 
     StatusBaseText {
         id: title
+        width: parent.width
         verticalAlignment: Text.AlignVCenter
         font.pixelSize: 13
         color: Theme.palette.baseColor1
@@ -46,6 +47,7 @@ Column {
         columns: 6
         rowSpacing: 16
         columnSpacing: 32
+
         Repeater {
             objectName: "statusColorRepeater"
             model: root.model


### PR DESCRIPTION
1. As discussed with John, fixed `StatusColorRadioButton` size to 44px. Designs will be updated later.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
