### PR TITLE
feat(StatusListItem): Added `loading` and `loadingFailed` properties

### DIFF
--- a/sandbox/controls/ListItems.qml
+++ b/sandbox/controls/ListItems.qml
@@ -445,4 +445,33 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
         isAdmin: true
         isUntrustworthy: true
     }
+
+    StatusBaseText {
+        Layout.fillWidth: true
+        Layout.topMargin: 16
+        text: "Loading features:"
+        font.pixelSize: 17
+    }
+
+    StatusListItem {
+        title: "Nokia 3310"
+        subTitle: "Incoming device"
+        label: "loading: true"
+        icon.emoji: "😁"
+        icon.color: "hotpink"
+        icon.letterSize: 14
+        icon.isLetterIdenticon: true
+        loading: true
+    }
+
+    StatusListItem {
+        title: "Nokia 3310"
+        subTitle: "Device"
+        label: "loadingFailed: true"
+        icon.emoji: "😁"
+        icon.color: "hotpink"
+        icon.letterSize: 14
+        icon.isLetterIdenticon: true
+        loadingFailed: true
+    }
 }

--- a/src/StatusQ/Animations/SkeletonAnimation.qml
+++ b/src/StatusQ/Animations/SkeletonAnimation.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.14
+import QtGraphicalEffects 1.14
+
+Item {
+    id: root
+
+    property Item mask
+    property color color: "#F6F8FA"
+
+    Rectangle {
+        id: gradient
+        anchors.fill: parent
+        visible: false
+
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+            SkeletonGradientStop { color: "transparent"; from: -3; }
+            SkeletonGradientStop { color: "transparent"; from: -2; }
+            SkeletonGradientStop { color: root.color; from: -1 ; }
+            SkeletonGradientStop { color: "transparent"; from: 0; }
+            SkeletonGradientStop { color: "transparent"; from: 1; }
+        }
+    }
+
+    OpacityMask {
+        anchors.fill: parent
+        source: gradient
+        maskSource: root.mask
+    }
+}

--- a/src/StatusQ/Animations/SkeletonGradientStop.qml
+++ b/src/StatusQ/Animations/SkeletonGradientStop.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.14
+import QtGraphicalEffects 1.14
+
+/*
+    TODO:   This component should be implemented as inline component of `SkeletonAnimation.qml`
+            when we use Qt > 5.15
+*/
+
+GradientStop {
+    id: root
+
+    property real from: 0
+
+    color: "transparent"
+
+    NumberAnimation on position {
+        easing.type: Easing.Linear
+        loops: Animation.Infinite
+        from: root.from
+        to: from + 4
+        duration: 2000
+    }
+}

--- a/src/StatusQ/Animations/qmldir
+++ b/src/StatusQ/Animations/qmldir
@@ -1,0 +1,4 @@
+module StatusQ.Animations
+
+SkeletonAnimation 0.1 SkeletonAnimation.qml
+SkeletonGradientStop 0.1 SkeletonGradientStop.qml

--- a/statusq.qrc
+++ b/statusq.qrc
@@ -10502,5 +10502,8 @@
         <file>src/assets/twemoji/LICENSE</file>
         <file>src/StatusQ/Controls/StatusTabBar.qml</file>
         <file>src/StatusQ/Controls/StatusTagItem.qml</file>
+        <file>src/StatusQ/Animations/SkeletonAnimation.qml</file>
+        <file>src/StatusQ/Animations/SkeletonGradientStop.qml</file>
+        <file>src/StatusQ/Animations/qmldir</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
1. `loading` property 
Show a "skeleton" animation on `iconOrImage` and `title` items

2. `loadingFailed` property
Makes `iconOrImage` and `title` of danger colors

Designs taken from [this Figma](https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1592%3A129523). It doesn't describe animation though, I designed it myself.

https://user-images.githubusercontent.com/25482501/174477913-4c0f1882-b443-46a3-a4de-515a92ee86bc.mov

https://user-images.githubusercontent.com/25482501/174477916-605ab6bd-8f94-4ff4-8883-461cca3c4b2f.mov


### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
