### PR TITLE
chore(StatusFlatRoundButon): fix warning related to hovered property

### DIFF
--- a/src/StatusQ/Controls/StatusFlatRoundButton.qml
+++ b/src/StatusQ/Controls/StatusFlatRoundButton.qml
@@ -172,6 +172,6 @@ Rectangle {
 
     StatusToolTip {
         id: statusToolTip
-        visible: !!text && parent.hovered
+        visible: !!text && statusFlatRoundButton.hovered
     } // Tooltip
 } // Rectangle


### PR DESCRIPTION
Small fix. The warning appeared when switching channels. The parent must have not been initiated or something. Using the ID solves the issue.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
