### PR TITLE
feat(StatusRoundButton): Added `Tertiary` type

### DIFF
--- a/sandbox/controls/Buttons.qml
+++ b/sandbox/controls/Buttons.qml
@@ -174,6 +174,25 @@ Column {
             loading: true
         }
 
+        // transparent
+
+        StatusRoundButton {
+            type: StatusRoundButton.Type.Tertiary
+            icon.name: "info"
+        }
+
+        StatusRoundButton {
+            type: StatusRoundButton.Type.Tertiary
+            icon.name: "info"
+            enabled: false
+        }
+
+        StatusRoundButton {
+            type: StatusRoundButton.Type.Tertiary
+            icon.name: "info"
+            loading: true
+        }
+
         // Rounded blue
 
         StatusFlatRoundButton {

--- a/src/StatusQ/Controls/StatusRoundButton.qml
+++ b/src/StatusQ/Controls/StatusRoundButton.qml
@@ -12,14 +12,27 @@ Rectangle {
         height: 23
         rotation: 0
 
+        property color hoverColor: {
+            switch(statusRoundButton.type) {
+            case StatusRoundButton.Type.Primary:
+                return Theme.palette.primaryColor1;
+            case StatusRoundButton.Type.Secondary:
+                return Theme.palette.indirectColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return Theme.palette.primaryColor1;
+            }
+        }
+
         color: {
             switch(statusRoundButton.type) {
             case StatusRoundButton.Type.Primary:
                 return Theme.palette.primaryColor1;
             case StatusRoundButton.Type.Secondary:
                 return Theme.palette.indirectColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return Theme.palette.baseColor1;
             }
-        }
+        }        
 
         disabledColor: {
             switch(statusRoundButton.type) {
@@ -27,6 +40,8 @@ Rectangle {
                 return Theme.palette.baseColor1;
             case StatusRoundButton.Type.Secondary:
                 return Theme.palette.indirectColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return Theme.palette.baseColor1;
             }
         }
     }
@@ -46,7 +61,8 @@ Rectangle {
 
     enum Type {
         Primary,
-        Secondary
+        Secondary,
+        Tertiary
     }
     /// Implementation
 
@@ -59,6 +75,8 @@ Rectangle {
                 return Theme.palette.primaryColor3;
             case StatusRoundButton.Type.Secondary:
                 return Theme.palette.primaryColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return "transparent";
             }
         }
 
@@ -68,6 +86,8 @@ Rectangle {
                 return Theme.palette.primaryColor2;
             case StatusRoundButton.Type.Secondary:
                 return Theme.palette.miscColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return Theme.palette.primaryColor3;
             }
         }
 
@@ -77,13 +97,17 @@ Rectangle {
                 return Theme.palette.baseColor2;
             case StatusRoundButton.Type.Secondary:
                 return Theme.palette.baseColor1;
+            case StatusRoundButton.Type.Tertiary:
+                return "transparent";
             }
         }
     }
 
     QtObject {
         id: d
-        readonly property color iconColor: statusRoundButton.enabled ? statusRoundButton.icon.color : statusRoundButton.icon.disabledColor
+        readonly property color iconColor: !statusRoundButton.enabled ? statusRoundButton.icon.disabledColor :
+                                                                        (statusRoundButton.enabled && statusRoundButton.hovered) ? statusRoundButton.icon.hoverColor :
+                                                                                                                                   statusRoundButton.icon.color
     }
 
     implicitWidth: 44


### PR DESCRIPTION
- Transparent background but when hovered, like Primary type in idle state.

- Updated sandbox with the new type.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)


https://user-images.githubusercontent.com/97019400/175244789-58e0c37a-cb2b-4088-887f-a24fabf292dc.mov
