### PR TITLE
fix(StatusChatToolBar): Updated activity center button size

### DIFF
--- a/src/StatusQ/Components/StatusChatToolBar.qml
+++ b/src/StatusQ/Components/StatusChatToolBar.qml
@@ -137,6 +137,8 @@ Item {
 
             StatusActivityCenterButton {
                 id: notificationButton
+                width: 32
+                height: width
                 unreadNotificationsCount: statusChatToolBar.notificationCount
                 onClicked: statusChatToolBar.notificationButtonClicked()
             }

--- a/src/StatusQ/Controls/StatusActivityCenterButton.qml
+++ b/src/StatusQ/Controls/StatusActivityCenterButton.qml
@@ -31,9 +31,6 @@ StatusFlatRoundButton {
     */
     property alias unreadNotificationsCount: statusBadge.value
 
-    implicitWidth: 32
-    implicitHeight: 32
-
     icon.name: "notification"
     icon.height: 21
     type: StatusFlatRoundButton.Type.Secondary


### PR DESCRIPTION
Activity center button has now the same size than the other toolbar buttons.

Fixes https://github.com/status-im/status-desktop/issues/6216

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)

https://user-images.githubusercontent.com/97019400/175265391-383f9bfa-23af-4524-91f6-75e323c554f9.mov



