### PR TITLE
fix(@sandbox): greatly speed up (re)build times

### DIFF
--- a/sandbox/sandbox.pro
+++ b/sandbox/sandbox.pro
@@ -1,11 +1,13 @@
 QT += quick svg
 
 CONFIG += c++11 warn_on qtquickcompiler
+CONFIG += resources_big
 
 QML_IMPORT_PATH= $$PWD/../src
 
 DEFINES += QT_DEPRECATED_WARNINGS
 
+QMAKE_LFLAGS += $$(LDFLAGS)
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.


### PR DESCRIPTION
since most of the compilation time is spent on creating the QRC bundle
and the resulting binary is quite huge, advice the `rcc` compiler to add
support for "big resources"
(cf https://doc.qt.io/qt-6/resources.html#embedding-large-files)

Also pass the env $LDFLAGS to qmake (to be able to link e.g. with mold,
which again greatly reduces the time to link the binary)

this leads to 6-10x faster time when recompiling
(Linux, gcc 12.1.1, mold 1.3.0)

BEFORE:
Clean build:
real	0m57,256s
user	1m25,869s
sys	0m40,963s

Incremental build, one file touched:
real	0m54,323s
user	0m54,012s
sys	0m2,934s

AFTER:
Clean build:
real	0m7,276s
user	0m21,001s
sys	0m37,256s

Incremental build, one file touched:
real	0m5,569s
user	0m4,850s
sys	0m0,840s

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
