### PR TITLE
feat(StatusStackModal): add subheader and remove explicit width

### DIFF
--- a/src/StatusQ/Popups/StatusStackModal.qml
+++ b/src/StatusQ/Popups/StatusStackModal.qml
@@ -8,30 +8,20 @@ import StatusQ.Controls 0.1
 StatusModal {
     id: root
 
-    /*
-    stackItems
-    Attached properties:
-        canGoNext
-
-    replaceItem
-    Attached properties:
-        title
-        acceptButton
-    */
-
     property string stackTitle: qsTr("StackModal")
+    property int subHeaderPadding: 16
 
     property alias stackItems: stackLayout.children
     property alias currentIndex: stackLayout.currentIndex
     property alias replaceItem: replaceLoader.sourceComponent
+    property alias subHeaderItem: subHeaderLoader.sourceComponent
 
     readonly property int itemsCount: stackLayout.children.length
     readonly property var currentItem: stackLayout.currentItem
 
     property Item nextButton: StatusButton {
         text: qsTr("Next")
-        enabled: !!currentItem && (typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext)
-        onClicked: currentIndex++
+        onClicked: root.currentIndex++
     }
 
     property Item finishButton: StatusButton {
@@ -57,11 +47,9 @@ StatusModal {
     onCurrentIndexChanged: updateRightButtons()
     onReplaceItemChanged: updateRightButtons()
 
-    width: 640
-    padding: 16
-
     header.title: replaceLoader.item && typeof(replaceLoader.item.title) != "undefined"
                                                 ? replaceLoader.item.title : stackTitle
+    padding: 16
 
     leftButtons: StatusRoundButton {
         id: backButton
@@ -83,20 +71,33 @@ StatusModal {
     Item {
         id: content
         anchors.fill: parent
-        implicitWidth: Math.max(stackLayout.implicitWidth, replaceLoader.implicitWidth)
-        implicitHeight: Math.max(stackLayout.implicitHeight, replaceLoader.implicitHeight)
-        clip: true
+        implicitWidth: Math.max(stackLayout.implicitWidth, subHeaderLoader.implicitWidth, replaceLoader.implicitWidth)
+        implicitHeight: Math.max(stackLayout.implicitHeight +
+                         (subHeaderLoader.item && subHeaderLoader.item.visible ? subHeaderLoader.height + root.subHeaderPadding : 0),
+                         replaceLoader.implicitHeight)
+
+        Loader {
+            id: subHeaderLoader
+            anchors.top: parent.top
+            width: parent.width
+            clip: true
+        }
 
         StatusAnimatedStack {
             id: stackLayout
-            anchors.fill: parent
+            anchors.top: subHeaderLoader.bottom
+            anchors.topMargin: subHeaderLoader.item && subHeaderLoader.item.visible ? root.subHeaderPadding : 0
+            anchors.bottom: parent.bottom
+            width: parent.width
             visible: !replaceItem
+            clip: true
         }
 
         Loader {
             id: replaceLoader
             anchors.fill: parent
             visible: item
+            clip: true
             onItemChanged: {
                 root.rightButtons = item ? item.rightButtons : [ nextButton, finishButton ]
                 if (!item && root.itemsCount == 0) {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/pull/6270

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
