### PR TITLE
fix(sandbox): enable the hover effects by default

### DIFF
--- a/sandbox/main.cpp
+++ b/sandbox/main.cpp
@@ -12,6 +12,8 @@ int main(int argc, char *argv[])
 
     SandboxApp app(argc, argv);
 
+    qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", QByteArrayLiteral("1"));
+
     app.setOrganizationName("Status");
     app.setOrganizationDomain("status.im");
     app.setApplicationName("Sandbox");


### PR DESCRIPTION
Similar to what we did in status desktop under [@status-im/status-desktop/#6335](https://github.com/status-im/status-desktop/pull/6335)

- since Qt 5.xy, hover is not enabled by default for QQC2, so enable it
unconditionally as we are a desktop app anyway
- this fixes several hover effects being broken, mostly for builtin
components like MenuItem and some buttons (eg. the leftmost NavBar)
where we haven't enabled those with `hoverEnabled: true` explicitely

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
