### PR TITLE
fix: handle animations by higher level nodes or states

### DIFF
--- a/src/StatusQ/Components/StatusExpandableItem.qml
+++ b/src/StatusQ/Components/StatusExpandableItem.qml
@@ -217,12 +217,12 @@ Rectangle {
         Transition {
             from: "COLLAPSED"
             to: "EXPANDED"
-            NumberAnimation { properties: "height"; duration: 200; running: visible }
+            NumberAnimation { properties: "height"; duration: 200;}
         },
         Transition {
             from: "EXPANDED"
             to: "COLLAPSED"
-            NumberAnimation { properties: "height"; duration: 200; running: visible }
+            NumberAnimation { properties: "height"; duration: 200;}
         }
     ]
 }

--- a/src/StatusQ/Controls/StatusPinInput.qml
+++ b/src/StatusQ/Controls/StatusPinInput.qml
@@ -212,8 +212,8 @@ Item {
                          id: blinkingAnimation
                          loops: Animation.Infinite
                          running: visible
-                         NumberAnimation { target: inner; property: "opacity"; to: 0; duration: 800; running: visible }
-                         NumberAnimation { target: inner; property: "opacity"; to: 1; duration: 800; running: visible }
+                         NumberAnimation { target: inner; property: "opacity"; to: 0; duration: 800;}
+                         NumberAnimation { target: inner; property: "opacity"; to: 1; duration: 800;}
                      }
                  }
             }

--- a/src/StatusQ/Controls/StatusSwitch.qml
+++ b/src/StatusQ/Controls/StatusSwitch.qml
@@ -52,7 +52,7 @@ Switch {
 
             transitions: Transition {
                 reversible: true
-                NumberAnimation { properties: "x"; easing.type: Easing.Linear; duration: 120; running: visible }
+                NumberAnimation { properties: "x"; easing.type: Easing.Linear; duration: 120}
             }
         }
     }


### PR DESCRIPTION
I have noticed that there are lot of: `QML NumberAnimation: setRunning() cannot be used on non-root animation nodes` WRNgs in logs - as also @caybro [noticed](https://github.com/status-im/StatusQ/pull/744#issuecomment-1171037383). Looks like they are pointing to animations with `running:` property set when higher level nodes (animations or states) are handling `running`.

This PR is to fix the warnings and let QT decide when animation should be running:
a) in transitions: when states are changing
b) in nested animations: higher level animation should handle "children" animations

_This is my very first PR in this repos, so Hi!_ 👋 😄 


### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
