### PR TITLE
fix(StatusIcon): flag/currency icons are rendered blurred

### DIFF
--- a/sandbox/demoapp/data/Models.qml
+++ b/sandbox/demoapp/data/Models.qml
@@ -1000,7 +1000,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "United States Dollar"
             shortName: "USD"
             symbol: "$"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: ""
             selected: false
         }
@@ -1009,7 +1009,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "British Pound"
             shortName: "GBP"
             symbol: "£"
-            imageSource: "../../assets/twemoji/26x26/1f4b5.png"
+            imageSource: "../../assets/twemoji/svg/1f4b5.svg"
             category: ""
             selected: false
         }
@@ -1018,7 +1018,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Euro"
             shortName: "EUR"
             symbol: "€"
-            imageSource: "../../assets/twemoji/26x26/1f4b6.png"
+            imageSource: "../../assets/twemoji/svg/1f4b6.svg"
             category: ""
             selected: true
         }
@@ -1027,7 +1027,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Shout Korean Won"
             shortName: "KRW"
             symbol: "₩"
-            imageSource: "../../assets/twemoji/26x26/1f4b8.png"
+            imageSource: "../../assets/twemoji/svg/1f4b8.svg"
             category: ""
             selected: false
         }
@@ -1036,7 +1036,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Ethereum"
             shortName: "ETH"
             symbol: "Ξ"
-            imageSource: "../../assets/twemoji/26x26/1f4b7.png"
+            imageSource: "../../assets/twemoji/svg/1f4b7.svg"
             category: "Tokens"
             selected: true
         }
@@ -1045,7 +1045,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Bitcoin"
             shortName: "BTC"
             symbol: "฿"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Tokens"
             selected: false
         }
@@ -1054,7 +1054,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Status Network Token"
             shortName: "SNT"
             symbol: ""
-            imageSource: "../../assets/twemoji/26x26/1f4b8.png"
+            imageSource: "../../assets/twemoji/svg/1f4b8.svg"
             category: "Tokens"
             selected: false
         }
@@ -1064,7 +1064,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Emirati Dirham"
             shortName: "AED"
             symbol: "د.إ"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1073,7 +1073,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Afghani"
             shortName: "AFN"
             symbol: "؋"
-            imageSource: "../../assets/twemoji/26x26/1f4b7.png"
+            imageSource: "../../assets/twemoji/svg/1f4b7.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1082,7 +1082,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Argentine Peso"
             shortName: "AFN"
             symbol: "$"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1094,7 +1094,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "United States Dollar"
             shortName: "USD"
             symbol: "$"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: ""
             selected: false
         }
@@ -1103,7 +1103,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "British Pound"
             shortName: "GBP"
             symbol: "£"
-            imageSource: "../../assets/twemoji/26x26/1f4b5.png"
+            imageSource: "../../assets/twemoji/svg/1f4b5.svg"
             category: ""
             selected: false
         }
@@ -1112,7 +1112,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Euro"
             shortName: "EUR"
             symbol: "€"
-            imageSource: "../../assets/twemoji/26x26/1f4b6.png"
+            imageSource: "../../assets/twemoji/svg/1f4b6.svg"
             category: ""
             selected: true
         }
@@ -1121,7 +1121,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Shout Korean Won"
             shortName: "KRW"
             symbol: "₩"
-            imageSource: "../../assets/twemoji/26x26/1f4b8.png"
+            imageSource: "../../assets/twemoji/svg/1f4b8.svg"
             category: ""
             selected: false
         }
@@ -1130,7 +1130,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Ethereum"
             shortName: "ETH"
             symbol: "Ξ"
-            imageSource: "../../assets/twemoji/26x26/1f4b7.png"
+            imageSource: "../../assets/twemoji/svg/1f4b7.svg"
             category: "Tokens"
             selected: true
         }
@@ -1139,7 +1139,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Bitcoin"
             shortName: "BTC"
             symbol: "฿"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Tokens"
             selected: false
         }
@@ -1148,7 +1148,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Status Network Token"
             shortName: "SNT"
             symbol: ""
-            imageSource: "../../assets/twemoji/26x26/1f4b8.png"
+            imageSource: "../../assets/twemoji/svg/1f4b8.svg"
             category: "Tokens"
             selected: false
         }
@@ -1158,7 +1158,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Emirati Dirham"
             shortName: "AED"
             symbol: "د.إ"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1167,7 +1167,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Afghani"
             shortName: "AFN"
             symbol: "؋"
-            imageSource: "../../assets/twemoji/26x26/1f4b7.png"
+            imageSource: "../../assets/twemoji/svg/1f4b7.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1176,7 +1176,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             name: "Argentine Peso"
             shortName: "AFN"
             symbol: "$"
-            imageSource: "../../assets/twemoji/26x26/1f4b4.png"
+            imageSource: "../../assets/twemoji/svg/1f4b4.svg"
             category: "Other Fiat"
             selected: false
         }
@@ -1187,7 +1187,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 0
             name: "English"
             shortName: "English"
-            imageSource: "../../assets/twemoji/26x26/1f1ec-1f1e7.png"
+            imageSource: "../../assets/twemoji/svg/1f1ec-1f1e7.svg"
             category: ""
             selected: false
         }
@@ -1195,7 +1195,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 1
             name: "Korean"
             shortName: "한국어"
-            imageSource: "../../assets/twemoji/26x26/1f1f0-1f1f7.png"
+            imageSource: "../../assets/twemoji/svg/1f1f0-1f1f7.svg"
             category: ""
             selected: false
         }
@@ -1203,7 +1203,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 2
             name: "Portuguese (Brazilian)"
             shortName: "Português"
-            imageSource: "../../assets/twemoji/26x26/1f1e7-1f1f7.png"
+            imageSource: "../../assets/twemoji/svg/1f1e7-1f1f7.svg"
             category: ""
             selected: true
         }
@@ -1211,7 +1211,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 3
             name: "Dutch"
             shortName: "Nederlands"
-            imageSource: "../../assets/twemoji/26x26/1f1f3-1f1f1.png"
+            imageSource: "../../assets/twemoji/svg/1f1f3-1f1f1.svg"
             category: "Beta Languages"
             selected: false
         }
@@ -1219,7 +1219,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 4
             name: "Indonesian"
             shortName: "Bahasa Indonesia"
-            imageSource: "../../assets/twemoji/26x26/1f1ee-1f1e9.png"
+            imageSource: "../../assets/twemoji/svg/1f1ee-1f1e9.svg"
             category: "Beta Languages"
             selected: false
         }
@@ -1227,7 +1227,7 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
             key: 5
             name: "Spanish"
             shortName: "Español"
-            imageSource: "../../assets/twemoji/26x26/1f1ea-1f1e6.png"
+            imageSource: "../../assets/twemoji/svg/1f1ea-1f1e6.svg"
             category: "Beta Languages"
             selected: false
         }

--- a/src/StatusQ/Core/StatusIcon.qml
+++ b/src/StatusQ/Core/StatusIcon.qml
@@ -8,12 +8,9 @@ Image {
     id: statusIcon
     width: 24
     height: 24
-    sourceSize.width: width
-    sourceSize.height: height
+    // SVGs must have sourceSize, PNGs not; otherwise blurry
+    sourceSize: !!icon ? Qt.size(width, height) : undefined
     fillMode: Image.PreserveAspectFit
-
-    antialiasing: true
-    mipmap: true
 
     onIconChanged: {
         if (icon !== "") {
@@ -21,10 +18,9 @@ Image {
         }
     }
 
-    layer.mipmap: true
     layer.smooth: true
     layer.format: ShaderEffectSource.RGBA
-    layer.enabled:!Qt.colorEqual(statusIcon.color, "transparent")
+    layer.enabled: !Qt.colorEqual(statusIcon.color, "transparent")
     layer.effect: ColorOverlay {
         color: statusIcon.color
     }


### PR DESCRIPTION
- set the Image's `sourceSize` only if it's an SVG, otherwise it is
rendered blurry
- remove antialiasing/mipmap; it's not the correct fix, doesn't really
improve the visual quality for smallish items like icons and just causes
memory/GPU overhead

### Screenshots (before/after)
![Snímek obrazovky z 2022-07-05 22-35-38](https://user-images.githubusercontent.com/5377645/177520497-daed4b44-f8e8-4d9e-a754-76464422f2ba.png)
![Snímek obrazovky z 2022-07-05 23-08-53](https://user-images.githubusercontent.com/5377645/177520505-8438072b-7805-4923-92ad-c43e09a42389.png)

### status-desktop screenshot
![Snímek obrazovky z 2022-07-06 11-52-19](https://user-images.githubusercontent.com/5377645/177523723-7d1639c7-152f-4d3d-9e18-7e72cd062845.png)


### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
