### PR TITLE
fix(StatusSwitch): Removed `running` property on transition animation

### DIFF
--- a/src/StatusQ/Controls/StatusSwitch.qml
+++ b/src/StatusQ/Controls/StatusSwitch.qml
@@ -52,7 +52,7 @@ Switch {
 
             transitions: Transition {
                 reversible: true
-                NumberAnimation { properties: "x"; easing.type: Easing.Linear; duration: 120; running: visible }
+                NumberAnimation { properties: "x"; easing.type: Easing.Linear; duration: 120 }
             }
         }
     }


### PR DESCRIPTION
This was probably made by mistake and doesn't actually makes sense.
This was causing an annoying warning:
```
QML NumberAnimation: setRunning() cannot be used on non-root animation nodes.
```

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
