### PR TITLE
fix(StatusStackModal): init the next/finish buttons

### DIFF
--- a/src/StatusQ/Popups/StatusStackModal.qml
+++ b/src/StatusQ/Popups/StatusStackModal.qml
@@ -16,7 +16,7 @@ StatusModal {
     property alias replaceItem: replaceLoader.sourceComponent
     property alias subHeaderItem: subHeaderLoader.sourceComponent
 
-    readonly property int itemsCount: stackLayout.children.length
+    readonly property int itemsCount: stackLayout.count
     readonly property var currentItem: stackLayout.currentItem
 
     property Item nextButton: StatusButton {
@@ -44,6 +44,7 @@ StatusModal {
         }
     }
 
+    Component.onCompleted: updateRightButtons()
     onCurrentIndexChanged: updateRightButtons()
     onReplaceItemChanged: updateRightButtons()
 


### PR DESCRIPTION
call `updateRightButtons()` also on creation to correctly initialize the
Next and Finish buttons in derived classes, when one overrrides these

can be seen in the Backup Seed dialog where the Next button is not
enabled even though all 3 boxes are checked

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
