### PR TITLE
feat(StatusStackModal): introduce `prevAction` API

### DIFF
--- a/src/StatusQ/Popups/StatusStackModal.qml
+++ b/src/StatusQ/Popups/StatusStackModal.qml
@@ -60,10 +60,15 @@ StatusModal {
         rotation: 180
         visible: replaceItem || stackLayout.currentIndex > 0
         onClicked: {
-            if (replaceItem)
-                replaceItem = null;
-            else
-                stackLayout.currentIndex--;
+            if (replaceItem) {
+              replaceItem = null;
+            } else {
+              let prevAction = stackLayout.currentItem.prevAction
+              stackLayout.currentIndex--;
+              if (typeof(prevAction) == "function") {
+                prevAction()
+              }
+            }
         }
     }
 


### PR DESCRIPTION
This adds a possible `prevAction` hook to `stackLayout.currentItem`
which is triggered (if it exists) when the stack modal's back button is
hit.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
