### PR TITLE
fix(StatusAssetSelector): Fixes the issue of longer text overlapping with the arrow.

### DIFF
--- a/sandbox/pages/StatusAssetSelectorPage.qml
+++ b/sandbox/pages/StatusAssetSelectorPage.qml
@@ -25,14 +25,24 @@ Column {
                 name: "Status Network Token"
                 balance: "20"
                 symbol: "SNT"
-                currencyBalance: 9992.01
+                totalCurrencyBalance: 9992.01
+                totalBalance: 9992.01
             }
             ListElement {
                 address: "0x1234"
                 name: "DAI Token"
                 balance: "15"
                 symbol: "DAI"
-                currencyBalance: 20.00001
+                totalCurrencyBalance: 20.00001
+                totalBalance: 20.00001
+            }
+            ListElement {
+                address: "0x1234"
+                name: "ABYSS Token"
+                balance: "25"
+                symbol: "ABYSS"
+                totalCurrencyBalance: 24.1
+                totalBalance: 24.1
             }
         }
     }

--- a/src/StatusQ/Controls/StatusAssetSelector.qml
+++ b/src/StatusQ/Controls/StatusAssetSelector.qml
@@ -18,7 +18,7 @@ Item {
     }
     // Define this in the usage to get balance in currency selected by user
     property var getCurrencyBalanceString: function (currencyBalance) { return "" }
-    implicitWidth: 86
+    implicitWidth: 106
     implicitHeight: 32
 
     function resetInternal() {
@@ -65,6 +65,8 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: 15
                 height: 22
+                width: 50
+                elide: Text.ElideRight
                 verticalAlignment: Text.AlignVCenter
                 color: Theme.palette.directColor1
             }


### PR DESCRIPTION
 fix(StatusAssetSelector): Fixes the issue of longer text overlapping with the arrow. 
Have also added a max width for the text after which it should elide

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
