### PR TITLE
hotfix(StatusCheckBox): enable setting the font size

### DIFF
--- a/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/src/StatusQ/Controls/StatusCheckBox.qml
@@ -32,6 +32,7 @@ CheckBox {
 
     contentItem: StatusBaseText {
         text: statusCheckBox.text
+        font.pixelSize: statusCheckBox.font.pixelSize
         opacity: enabled ? 1.0 : 0.3
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.WordWrap


### PR DESCRIPTION
add a possibility to override the font size for the contentItem's StatusBaseText

otherwise it's impossible to do stuff like:
```qml
StatusCheckBox {
  font.pixelSize: 15
}
```

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
