### PR TITLE
feat(StatusColorRadioButton): expose radio button diameter property

### DIFF
--- a/src/StatusQ/Controls/StatusColorRadioButton.qml
+++ b/src/StatusQ/Controls/StatusColorRadioButton.qml
@@ -8,19 +8,21 @@ RadioButton {
 
     property string radioButtonColor: ""
     property string selectionColor: StatusColors.colors['white']
+    property int diameter: 48
+    property int selectorDiameter: 20
 
     implicitWidth: 48
     implicitHeight: 48
 
     indicator: Rectangle {
-        implicitWidth: 48
-        implicitHeight: 48
+        implicitWidth: control.diameter
+        implicitHeight: control.diameter
         radius: width/2
         color: radioButtonColor
 
         Rectangle {
-            width: 20
-            height: 20
+            width: control.selectorDiameter
+            height: control.selectorDiameter
             radius: width/2
             color: selectionColor
             border.color: StatusColors.colors['grey3']

--- a/src/StatusQ/Controls/StatusColorSelectorGrid.qml
+++ b/src/StatusQ/Controls/StatusColorSelectorGrid.qml
@@ -12,6 +12,9 @@ Column {
     property alias title: title
     property alias columns: grid.columns
 
+    property int diameter: 48
+    property int selectorDiameter: 20
+
     property int selectedColorIndex: 0
     property string selectedColor: ""
     property var model:[ StatusColors.colors['black'],
@@ -46,6 +49,10 @@ Column {
         Repeater {
             model: root.model
             delegate: StatusColorRadioButton {
+                implicitWidth: root.diameter
+                implicitHeight: root.diameter
+                diameter: root.diameter
+                selectorDiameter: root.selectorDiameter
                 checked: index === selectedColorIndex
                 radioButtonColor: root.model[index] || "transparent"
                 onCheckedChanged: {


### PR DESCRIPTION
Expose diameters properties to adjust StatusColorRadioButtons to design: https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2457%3A345186

Required by Issue #5982

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
