### PR TITLE
feat(StatusChatListAndCategories) expose highlightItem prop from StatusChatListAndCategories

### DIFF
--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -13,6 +13,8 @@ Item {
     implicitHeight: chatListsAndCategories.height
     implicitWidth: chatListsAndCategories.width
 
+    property alias highlightItem: statusChatList.highlightItem
+
     property StatusTooltipSettings categoryAddButtonToolTip: StatusTooltipSettings {
         text: qsTr("Add channel inside category")
     }


### PR DESCRIPTION
Required by Issue status-im/status-desktop#6542

Exposes `highlightItem` from `StatusChatListAndCategories` for consistency with raw `StatusChatList` component.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
