### PR TITLE
fix(StatusBanner): TestNet banner overlaps left panel

### DIFF
--- a/src/StatusQ/Controls/StatusBanner.qml
+++ b/src/StatusQ/Controls/StatusBanner.qml
@@ -37,7 +37,7 @@ Column {
     */
     property string statusText
     /*!
-       \qmlproperty string StatusBanner::type
+       \qmlproperty int StatusBanner::type
        This property holds type of banner. Possible values are:
        \qml
         enum Type {
@@ -50,12 +50,12 @@ Column {
     */
     property int type: StatusBanner.Type.Info
     /*!
-       \qmlproperty string StatusBanner::textPixels
+       \qmlproperty int StatusBanner::textPixels
        This property holds the pixels size of the text inside the banner.
     */
     property int textPixels: 15
     /*!
-       \qmlproperty string StatusBanner::statusBannerHeight
+       \qmlproperty int StatusBanner::statusBannerHeight
        This property holds the height of the banner rectangle.
     */
     property int statusBannerHeight: 38
@@ -94,9 +94,12 @@ Column {
         StatusBaseText {
             id: statusTxt
             anchors.fill: parent
+            anchors.leftMargin: 8
+            anchors.rightMargin: 8
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             font.pixelSize: statusBanner.textPixels
+            elide: Text.ElideRight
             text: statusBanner.statusText
             color: d.fontColor
         }


### PR DESCRIPTION
let the text elide on the right side if the parent width is smaller
than ours

(also fix some docu typos)

Related: status-im/status-desktop#6600

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)

Screenshot with the fix:
![Snímek obrazovky z 2022-07-25 11-18-11](https://user-images.githubusercontent.com/5377645/180747001-54dff959-7bfd-45e7-af20-cbf3d651f547.png)

