### PR TITLE
fix(StatusSearchPopup): reset search location

### DIFF
--- a/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -30,6 +30,7 @@ StatusModal {
 
     signal resultItemClicked(string itemId)
     signal resultItemTitleClicked(string titleId)
+    signal resetSearchLocationClicked()
 
     property var formatTimestampFn: function (ts) {
         return ts
@@ -248,7 +249,7 @@ StatusModal {
                     type: StatusFlatRoundButton.Type.Secondary
                     icon.name: "close"
                     icon.color: Theme.palette.directColor1
-                    onClicked: { root.resetSearchSelection(); }
+                    onClicked: { root.resetSearchLocationClicked(); }
                 }
             }
             StatusMenuSeparator {


### PR DESCRIPTION
New `resetSearchLocationClicked` signal introduced.

Click on `X` button is emitting `resetSearchLocationClicked` signal and
lets a component which is using this one to decide what to do instead just
reseting search selection locally to this component.

Needed for https://github.com/status-im/status-desktop/issues/6551