### PR TITLE
Test/issue 6444 - Added `objectName` properties needed for automation

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -40,6 +40,7 @@ Column {
         model: statusChatList.model
         delegate: Item {
             id: draggable
+            objectName: model.name
             width: statusChatList.width
             height: statusChatListItem.height
             property alias chatListItem: statusChatListItem
@@ -210,6 +211,7 @@ Column {
 
     Repeater {
         id: statusChatListItems
+        objectName: "chatListItems"
         model: delegateModel
     }
 

--- a/src/StatusQ/Components/StatusTagSelector.qml
+++ b/src/StatusQ/Components/StatusTagSelector.qml
@@ -378,6 +378,7 @@ Item {
         }
         contentItem: ListView {
             id: userListView
+            objectName: "tagSelectorUserList"
             anchors {
                 fill: parent
                 topMargin: 16

--- a/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -6,6 +6,7 @@ import StatusQ.Components 0.1
 
 Rectangle {
     id: statusChatInfoButton
+    objectName: "chatInfoButton"
 
     implicitWidth: identicon.width +
                    Math.max(


### PR DESCRIPTION
 Added `objectName` properties needed for automation

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
