### PR TITLE
feat(StatusListView): Add availableWidth/availableHeight to api

### DIFF
--- a/src/StatusQ/Core/StatusListView.qml
+++ b/src/StatusQ/Core/StatusListView.qml
@@ -31,6 +31,9 @@ import StatusQ.Controls 0.1
 ListView {
     id: root
 
+    readonly property int availableWidth: width - leftMargin - rightMargin
+    readonly property int availableHeight: height - topMargin - bottomMargin
+
     clip: true
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: 2000


### PR DESCRIPTION
Tiny fix to make StatusListView and StatusScrollView more similar for usage. availableWidth/availableHeight can be used instead of anchors in StatusListView's delegate to get maximum size that doesn't cause scrolling
### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
