### PR TITLE
chore(StatusScrollView): remove unused background property

### DIFF
--- a/src/StatusQ/Core/StatusScrollView.qml
+++ b/src/StatusQ/Core/StatusScrollView.qml
@@ -37,16 +37,8 @@ Flickable {
     property int leftPadding: padding
     property int rightPadding: padding
 
-    property Item background: null
-
     readonly property int availableWidth: width - leftPadding - rightPadding
     readonly property int availableHeight: height - topPadding - bottomPadding
-
-    onBackgroundChanged: {
-        if (background) {
-            background.anchors.fill = root;
-        }
-    }
 
     // NOTE: in Qt6 clip true will be default
     clip: true


### PR DESCRIPTION
As part of https://github.com/status-im/status-desktop/issues/6609, I found that the backgropund property is no longer usable. I'm removing the use of `background` in status-desktop, which was only the CommunityColumnView.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [x] is this a breaking change?
    - [x] use the dedicated `BREAKING CHANGE` commit message section
    - [x] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [x] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
