### PR TITLE
fix(StatusAppNavBar): fix profile icon bottom margin

### DIFF
--- a/sandbox/qml.qrc
+++ b/sandbox/qml.qrc
@@ -44,7 +44,6 @@
         <file>images/SuperRareCommunityBanner.png</file>
         <file>pages/StatusAccountSelectorPage.qml</file>
         <file>pages/StatusAddressPage.qml</file>
-        <file>pages/StatusAssetSelectorPage.qml</file>
         <file>pages/StatusCardPage.qml</file>
         <file>pages/StatusChatCommandButtonPage.qml</file>
         <file>pages/StatusChatInfoToolBarPage.qml</file>

--- a/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -169,6 +169,6 @@ Rectangle {
         width: visible? statusAppNavBar.navBarProfileButton.width : 0
         visible: !!statusAppNavBar.navBarProfileButton
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: visible ? 32 : 0
+        anchors.bottomMargin: visible ? 24 : 0
     }
 }

--- a/src/statusq.qrc
+++ b/src/statusq.qrc
@@ -66,7 +66,6 @@
         <file>StatusQ/Controls/qmldir</file>
         <file>StatusQ/Controls/StatusAccountSelector.qml</file>
         <file>StatusQ/Controls/StatusActivityCenterButton.qml</file>
-        <file>StatusQ/Controls/StatusAssetSelector.qml</file>
         <file>StatusQ/Controls/StatusBanner.qml</file>
         <file>StatusQ/Controls/StatusBaseButton.qml</file>
         <file>StatusQ/Controls/StatusBaseInput.qml</file>


### PR DESCRIPTION
it should be 24px from the bottom according to the design

plus a hotfix to unbreak the build (StatusAssetSelector has been removed from sources but not from QRC)

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
