### PR TITLE
fix(StatusInput): Replaced layout spacing with margins

### DIFF
--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -348,7 +348,9 @@ Item {
     }
 
     implicitWidth: 448
-    implicitHeight: (internal.inputHeight + topRow.height + errorMessage.height + (2*inputLayout.spacing))
+    implicitHeight: ((internal.inputHeight + topRow.height + errorMessage.height) +
+                    ((topRow.height > 0) && (errorMessage.height > 0) ? 16 :
+                    (topRow.height > 0) || (errorMessage.height > 0) ? 8 : 0))
 
     Component.onCompleted: {
         validate()
@@ -357,7 +359,8 @@ Item {
     ColumnLayout {
         id: inputLayout
         anchors.fill: parent
-        spacing: ((topRow.height > 0) || (errorMessage.height > 0)) ? 8 : 0
+        spacing: 0
+
         RowLayout {
             id: topRow
             Layout.fillWidth: true
@@ -401,6 +404,8 @@ Item {
             id: statusBaseInput
             implicitWidth: parent.width
             implicitHeight: internal.inputHeight
+            Layout.alignment: Qt.AlignTop
+            Layout.topMargin: (topRow.height > 0) ? 8 : 0
             maximumLength: root.charLimit
             onTextChanged: root.validate()
             Keys.forwardTo: [root]
@@ -419,7 +424,8 @@ Item {
             height: visible ? contentHeight : 0
             font.pixelSize: 12
             color: Theme.palette.dangerColor1
-            Layout.alignment: Qt.AlignVCenter
+            Layout.alignment: Qt.AlignTop
+            Layout.topMargin: visible ? 8 : 0
             wrapMode: Text.WordWrap
         }
     }


### PR DESCRIPTION
As part of https://github.com/status-im/status-desktop/issues/6022

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
