### PR TITLE
chore(StatusListPicker): enable picker to work with incompatible models

### DIFF
--- a/src/StatusQ/Components/StatusListPicker.qml
+++ b/src/StatusQ/Components/StatusListPicker.qml
@@ -74,6 +74,8 @@ Item {
     */
     property var inputList: ListModel { }
 
+    readonly property StatusListPickerProxies proxy: StatusListPickerProxies {}
+
     /*!
        \qmlproperty string StatusListPicker::searchText
        This property holds the search text the searcher input displays by default.
@@ -160,7 +162,7 @@ Item {
             // NOTE: ValueFilter would crash if source model does not contain given role
             // FIXME: use ValueFilter when its fixed
             filters: ExpressionFilter {
-                expression: model.selected
+                expression: root.proxy.selected(model)
             }
         }
 
@@ -179,7 +181,7 @@ Item {
                 var item = selectedItems.get(i)
                 if(res != "")
                     res += ", "
-                res += formatSymbolShortNameText(item.symbol, item.shortName)
+                res += formatSymbolShortNameText(root.proxy.symbol(item), root.proxy.shortName(item))
             }
             return res
         }
@@ -200,8 +202,8 @@ Item {
             Connections {
                 target: itemsSelectorHelper
                 function onSelectItem(key, checked) {
-                    if (model.key === key) model.selected = checked
-                    else if (!root.multiSelection && checked) model.selected = false
+                    if (root.proxy.key(model) === key) root.proxy.setSelected(model, checked)
+                    else if (!root.multiSelection && checked) root.proxy.setSelected(model, false)
                 }
             }
         }
@@ -261,8 +263,8 @@ Item {
                 filters: ExpressionFilter {
                     expression: {
                         root.searchText // ensure expression is reevaluated when searchText changes
-                        return model.name.toLowerCase().includes(root.searchText.toLowerCase()) ||
-                               model.shortName.toLowerCase().includes(root.searchText.toLowerCase())
+                        return root.proxy.name(model).toLowerCase().includes(root.searchText.toLowerCase()) ||
+                               root.proxy.shortName(model).toLowerCase().includes(root.searchText.toLowerCase())
                     }
                 }
             }
@@ -302,24 +304,24 @@ Item {
                 height: content.itemHeight
                 color: mouseArea.containsMouse ? Theme.palette.baseColor4 : "transparent"
                 image: StatusImageSettings {
-                    source: model.imageSource ? model.imageSource : ""
+                    source: root.proxy.imageSource(model) ? root.proxy.imageSource(model) : ""
                     width: 15
                     height: 15
                     isIdenticon: false
                 }
-                name: model.name
-                shortName: model.shortName
+                name: root.proxy.name(model)
+                shortName: root.proxy.shortName(model)
                 selectorType: root.multiSelection ? StatusItemPicker.SelectorType.CheckBox : StatusItemPicker.SelectorType.RadioButton
-                selected: model.selected
+                selected: root.proxy.selected(model)
                 radioGroup: radioBtnGroup
 
                 onCheckedChanged: {
-                    if (checked !== model.selected) {
-                        itemsSelectorHelper.selectItem(model.key, checked)
+                    if (checked !== root.proxy.selected(model)) {
+                        itemsSelectorHelper.selectItem(root.proxy.key(model), checked)
                     }
 
                     // Used to notify selected property changes in the specific item picker.
-                    itemPickerChanged(model.key, checked)
+                    itemPickerChanged(root.proxy.key(model), checked)
                 }
 
                 MouseArea {
@@ -361,7 +363,7 @@ Item {
             // Not visual element to control mutual-exclusion of radiobuttons that are not sharing the same parent (inside list view)
             ButtonGroup {
                 id: radioBtnGroup
-            }           
-        }// End of Content        
+            }
+        }// End of Content
     }// End of Rectangle picker
 }

--- a/src/StatusQ/Components/StatusListPickerProxies.qml
+++ b/src/StatusQ/Components/StatusListPickerProxies.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.14
+
+/*!
+  Enables StatusListPicker to work with incompatible models.
+   \qml
+        StatusListPicker {
+            id: currencyPicker
+            inputList: ListModel {
+                ListElement { incompatibleA: 0 ... incomatibleZ: false }
+                ListElement { incompatibleA: 1 ... incomatibleZ: false }
+                ListElement { incompatibleA: 2 ... incomatibleZ: false }
+            }
+            proxy { // StatusListPickerProxies
+                key: (model) => model.incompatibleA
+                ...
+                selected: (model) => model.incompatibleZ
+            }
+        }
+   \endqml
+*/
+QtObject {
+    property var key: (model) => model.key
+    property var name: (model) => model.name
+    property var shortName: (model) => model.shortName
+    property var symbol: (model) => model.symbol
+    property var imageSource: (model) => model.imageSource
+    property var category: (model) => model.category
+    property var selected: (model) => model.selected
+    property var setSelected: (model, val) => model.selected = val
+}

--- a/src/statusq.qrc
+++ b/src/statusq.qrc
@@ -173,5 +173,6 @@
         <file>StatusQ/Popups/StatusSpellcheckingMenuItems.qml</file>
         <file>StatusQ/Popups/StatusStackModal.qml</file>
         <file>StatusQ/qmldir</file>
+        <file>StatusQ/Components/StatusListPickerProxies.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
needed by https://github.com/status-im/status-desktop/issues/6662, see: https://github.com/status-im/status-desktop/blob/c30a9b014919fc0ea0dc56742fd0d7dc26c16ce6/ui/app/AppLayouts/Profile/views/LanguageView.qml#L146-L154

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
