### PR TITLE
fix(StatusInput): setting default 44px in min/max height

### DIFF
--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -132,14 +132,14 @@ Item {
     property alias bottomPadding: statusBaseInput.bottomPadding
     /*!
         \qmlproperty real StatusInput::minimumHeight
-        This property sets the minimum height.
+        This property sets the minimum height. Default value is 44px.
     */
-    property real minimumHeight: 0
+    property real minimumHeight: 44
     /*!
         \qmlproperty alias StatusInput::maximumHeight
-        This property sets the maximum height.
+        This property sets the maximum height. Default value is 44px.
     */
-    property real maximumHeight: 0
+    property real maximumHeight: 44
     /*!
         \qmlproperty list StatusBaseInput::validators
         This property sets the list of validators to be considered.


### PR DESCRIPTION
### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
