### PR TITLE
fix(StatusSeedPhraseInput): Back up seed phrase inputs are missing spacing

### DIFF
--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -115,6 +115,7 @@ Item {
         id: seedWordInput
         implicitWidth: parent.width
         input.leftComponent: StatusBaseText {
+            rightPadding: 6
             text: root.leftComponentText
             color: seedWordInput.input.edit.activeFocus ?
                    Theme.palette.primaryColor1 : Theme.palette.baseColor1


### PR DESCRIPTION
Closes: status-im/status-desktop#6720

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)

Screenshots:
![Snímek obrazovky z 2022-08-02 11-59-59](https://user-images.githubusercontent.com/5377645/182358140-6961e36b-aa03-4c42-a109-b9e55b44eb68.png)

![Snímek obrazovky z 2022-08-02 12-53-54](https://user-images.githubusercontent.com/5377645/182358257-3dae966c-b6d9-4c0b-b6d7-6c4f9a9a5b30.png)


