### PR TITLE
chore(StatusChatList): Use SortFilterProxyModel instead of filtering functions

### DIFF
--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -23,8 +23,6 @@ Column {
 
     property Component popupMenu
 
-    property var filterFn
-
     signal chatItemSelected(string categoryId, string id)
     signal chatItemUnmuted(string id)
     signal chatItemReordered(string id, int from, int to)
@@ -44,13 +42,6 @@ Column {
             width: statusChatList.width
             height: statusChatListItem.height
             property alias chatListItem: statusChatListItem
-
-            visible: {
-                if (!!statusChatList.filterFn) {
-                    return statusChatList.filterFn(model)
-                }
-                return true
-            }
 
             MouseArea {
                 id: dragSensor

--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -7,6 +7,8 @@ import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Core 0.1
 
+import SortFilterProxyModel 0.2
+
 Item {
     id: statusChatListAndCategories
 
@@ -75,16 +77,27 @@ Item {
                 onChatItemUnmuted: statusChatListAndCategories.chatItemUnmuted(id)
                 onChatItemReordered: statusChatListAndCategories.chatItemReordered(categoryId, id, from, to)
                 draggableItems: statusChatListAndCategories.draggableItems
-                model: statusChatListAndCategories.model
-                filterFn: function (model) {
-                    return !model.isCategory
+
+                model: SortFilterProxyModel {
+                    sourceModel: statusChatListAndCategories.model
+
+                    filters: ValueFilter { roleName: "isCategory"; value: false }
+                    sorters: RoleSorter { roleName: "position" }
                 }
+
                 popupMenu: statusChatListAndCategories.chatListPopupMenu
             }
 
             DelegateModel {
                 id: delegateModel
-                model: statusChatListAndCategories.model
+
+                model: SortFilterProxyModel {
+                    sourceModel: statusChatListAndCategories.model
+
+                    filters: ValueFilter { roleName: "isCategory"; value: true }
+                    sorters: RoleSorter { roleName: "position" }
+                }
+
                 delegate: Item {
                     id: draggable
                     width: statusChatListCategory.width
@@ -139,7 +152,11 @@ Item {
                         showActionButtons: statusChatListAndCategories.showCategoryActionButtons
                         addButton.onClicked: statusChatListAndCategories.categoryAddButtonClicked(model.itemId)
 
-                        chatList.model: model.subItems
+                        chatList.model: SortFilterProxyModel {
+                            sourceModel: model.subItems
+                            sorters: RoleSorter { roleName: "position" }
+                        }
+
                         chatList.onChatItemSelected: statusChatListAndCategories.chatItemSelected(categoryId, id)
                         chatList.onChatItemUnmuted: statusChatListAndCategories.chatItemUnmuted(id)
                         chatList.onChatItemReordered: statusChatListAndCategories.chatItemReordered(model.itemId, id, from, to)

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -35,7 +35,6 @@ Column {
     StatusChatListCategoryItem {
         id: statusChatListCategoryItem
         title: statusChatListCategory.name
-        visible: model.isCategory
         opened: statusChatListCategory.opened
         sensor.pressAndHoldInterval: 150
 
@@ -66,9 +65,6 @@ Column {
         anchors.horizontalCenter: parent.horizontalCenter
         visible: statusChatListCategory.opened
         categoryId: statusChatListCategory.categoryId
-        filterFn: function (model) {
-            return !!model.parentItemId && model.parentItemId === statusChatList.categoryId
-        }
 
         popupMenu: statusChatListCategory.chatListPopupMenu
     }


### PR DESCRIPTION
This change is a necessary first step for further refactor of the functionality regarding community's chats list reordering and fixing bugs in this area.

Fixes: status-im/status-desktop#6709

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
