### PR TITLE
chore(StatusChatList): Keep sync with underlying model after reordering

### DIFF
--- a/src/StatusQ/Core/Utils/Utils.qml
+++ b/src/StatusQ/Core/Utils/Utils.qml
@@ -150,6 +150,29 @@ QtObject {
             context.stroke();
         }
     }
+
+    function delegateModelSort(srcGroup, dstGroup, lessThan) {
+        const insertPosition = (lessThan, item) => {
+            let lower = 0
+            let upper = dstGroup.count
+            while (lower < upper) {
+                const middle = Math.floor(lower + (upper - lower) / 2)
+                const result = lessThan(item.model, dstGroup.get(middle).model);
+                if (result)
+                    upper = middle
+                else
+                    lower = middle + 1
+            }
+            return lower
+        }
+
+        while (srcGroup.count > 0) {
+            const item = srcGroup.get(0)
+            const index = insertPosition(lessThan, item)
+            item.groups = dstGroup.name
+            dstGroup.move(item.itemsIndex, index)
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Checklist

After reordering chats or chat categories the order of elements in the list should reflect order in the underlying model. Reorders done via DelegateModel when dragging reordered item should be revoked to avoid improper sorting.

required by: status-im/status-desktop#6597, status-im/status-desktop#6722

affected:
StatusChatList, StatusChatListAndCategories

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
