### PR TITLE
fix(StatusImageCropPanel) vertically align slider in ImageCropPanel

### DIFF
--- a/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -242,13 +242,14 @@ Item {
             StatusIcon {
                 icon: "remove-circle"
 
+                Layout.alignment: Qt.AlignVCenter
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
             }
             StatusSlider {
                 Layout.fillWidth: true
                 Layout.topMargin: 20
-                Layout.bottomMargin: 25
+                Layout.bottomMargin: 20
                 Layout.alignment: Qt.AlignVCenter
 
                 enabled: root.interactive
@@ -262,6 +263,7 @@ Item {
             StatusIcon {
                 icon: "add-circle"
 
+                Layout.alignment: Qt.AlignVCenter
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
             }

--- a/src/StatusQ/Controls/StatusSlider.qml
+++ b/src/StatusQ/Controls/StatusSlider.qml
@@ -31,7 +31,8 @@ Slider {
         id: bgRect
 
         x: root.leftPadding
-        y: root.topPadding
+        anchors.verticalCenter: root.verticalCenter
+
         implicitWidth: 100
         implicitHeight: bgHeight
         width: root.availableWidth


### PR DESCRIPTION
- change StatusSlider y to be vertically centered

Fixes [#](https://github.com/status-im/status-desktop/issues/6725

Required by https://github.com/status-im/status-desktop/pull/6811

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)

StatusSlider after changes
![Screenshot from 2022-08-05 12-12-26](https://user-images.githubusercontent.com/6445843/183044862-3fd7b769-9629-49fa-907d-b2b3d976f5c1.png)
![Screenshot from 2022-08-05 12-12-31](https://user-images.githubusercontent.com/6445843/183044887-d5dc67f2-7ab3-4a12-aab8-6283cf6a11a1.png)

StatusImageCropPanel after changes
![Screenshot from 2022-08-05 12-11-43](https://user-images.githubusercontent.com/6445843/183044935-be804a72-78f3-4b20-8990-60b4ff70f277.png)
![Screenshot from 2022-08-05 12-11-49](https://user-images.githubusercontent.com/6445843/183044947-4761318b-9c75-46b8-9d9b-2b10e661235c.png)

Status-desktop fixed
![Screenshot from 2022-08-05 12-22-38](https://user-images.githubusercontent.com/6445843/183046887-3a70eff2-299c-44e3-a47d-93d4d4c23320.png)






