### PR TITLE
fix(StatusInput): Add labelPadding customisation and improve height calculation

### DIFF
--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -94,6 +94,11 @@ Item {
         \qmlproperty string StatusInput::label
         This property sets the label text.
     */
+    property int labelPadding: 8
+    /*!
+        \qmlproperty string StatusInput::label
+        This property sets the label text.
+    */
     property string label: ""
     /*!
         \qmlproperty string StatusInput::secondaryLabel
@@ -347,9 +352,7 @@ Item {
     }
 
     implicitWidth: 448
-    implicitHeight: ((internal.inputHeight + topRow.height + errorMessage.height) +
-                    ((topRow.height > 0) && (errorMessage.height > 0) ? 16 :
-                    (topRow.height > 0) || (errorMessage.height > 0) ? 8 : 0))
+    implicitHeight: inputLayout.implicitHeight
 
     Component.onCompleted: {
         validate()
@@ -363,7 +366,8 @@ Item {
         RowLayout {
             id: topRow
             Layout.fillWidth: true
-            Layout.preferredHeight: (!!root.label || !!root.secondaryLabel || root.charLimit > 0) ? 22 :0
+            Layout.preferredHeight: (!!root.label || !!root.secondaryLabel || root.charLimit > 0) ? 22 : 0
+
             StatusBaseText {
                 id: label
                 visible: !!text
@@ -404,7 +408,7 @@ Item {
             implicitWidth: parent.width
             implicitHeight: internal.inputHeight
             Layout.alignment: Qt.AlignTop
-            Layout.topMargin: (topRow.height > 0) ? 8 : 0
+            Layout.topMargin: (topRow.height > 0) ? labelPadding : 0
             maximumLength: root.charLimit
             onTextChanged: root.validate()
             Keys.forwardTo: [root]
@@ -419,13 +423,22 @@ Item {
 
         StatusBaseText {
             id: errorMessage
-            visible: !!text && !statusBaseInput.valid
-            height: visible ? contentHeight : 0
+            visible: {
+                if (!text)
+                    return false;
+
+                if ((root.validationMode == StatusInput.ValidationMode.OnlyWhenDirty && statusBaseInput.dirty) ||
+                    root.validationMode == StatusInput.ValidationMode.Always)
+                    return !statusBaseInput.valid;
+
+                return false;
+            }
             font.pixelSize: 12
             color: Theme.palette.dangerColor1
-            Layout.alignment: Qt.AlignTop
-            Layout.topMargin: visible ? 8 : 0
             wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignRight
+            Layout.topMargin: 8
+            Layout.fillWidth: true
         }
     }
 }


### PR DESCRIPTION

<img width="618" alt="Screenshot 2022-08-04 at 17 34 24" src="https://user-images.githubusercontent.com/2522130/182874033-f56ecad2-2373-4540-9484-f734cbaee146.png">

P.S i've fixed error message display in the component but there is still problem with Utils.getErrorMessage

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
