### PR TITLE
fix(StatusChatListCategory): Clicking on a category should toggle it

### DIFF
--- a/sandbox/controls/ListItems.qml
+++ b/sandbox/controls/ListItems.qml
@@ -56,19 +56,21 @@ ColumnLayout {
     }
 
     StatusChatListCategoryItem {
-        title: "Chat cat. interactive"
-        opened: true
-        propagateTitleClicks: false
+        id: categoryItemInteractive
+        title: "Chat category interactive"
         showActionButtons: true
         onAddButtonClicked: testEventsList.eventTriggered("Add button clicked")
         onMenuButtonClicked: testEventsList.eventTriggered("Menu button clicked")
-        onToggleButtonClicked: opened = !opened
+        onToggleButtonClicked: {
+            opened = !opened
+            testEventsList.eventTriggered("Toggle button clicked")
+        }
         onTitleClicked: {
             testEventsList.eventTriggered("Title clicked")
         }
         onClicked: {
-            testEventsList.eventTriggered("Item clicked")
-            mouse.accepted = true
+            opened = !opened
+            testEventsList.eventTriggered("Item clicked", itemId)
         }
     }
 
@@ -76,7 +78,7 @@ ColumnLayout {
         id: testEventsList
 
         Layout.fillWidth: true
-        Layout.preferredHeight: 20 * count
+        Layout.preferredHeight: categoryItemInteractive.opened ? 20 * count : 0
 
         clip: true
 
@@ -96,13 +98,13 @@ ColumnLayout {
 
                 Timer {
                     interval: 5000; running: true
-                    onTriggered: testObjeModel.remove(index)
+                    onTriggered: testObjectModel.remove(index)
                 }
             }
         }
 
         model: ObjectModel {
-            id: testObjeModel
+            id: testObjectModel
         }
     }
 

--- a/sandbox/controls/ListItems.qml
+++ b/sandbox/controls/ListItems.qml
@@ -1,4 +1,6 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQml.Models 2.14
 import QtQuick.Layouts 1.14
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -6,10 +8,8 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Utils 0.1
 
-GridLayout {
-    columns: 1
-    columnSpacing: 5
-    rowSpacing: 5
+ColumnLayout {
+    spacing: 5
 
     StatusNavigationListItem {
         title: "Menu Item"
@@ -53,6 +53,57 @@ GridLayout {
     StatusChatListCategoryItem {
         title: "Chat list category (no buttons)"
         opened: true
+    }
+
+    StatusChatListCategoryItem {
+        title: "Chat cat. interactive"
+        opened: true
+        propagateTitleClicks: false
+        showActionButtons: true
+        onAddButtonClicked: testEventsList.eventTriggered("Add button clicked")
+        onMenuButtonClicked: testEventsList.eventTriggered("Menu button clicked")
+        onToggleButtonClicked: opened = !opened
+        onTitleClicked: {
+            testEventsList.eventTriggered("Title clicked")
+        }
+        onClicked: {
+            testEventsList.eventTriggered("Item clicked")
+            mouse.accepted = true
+        }
+    }
+
+    ListView {
+        id: testEventsList
+
+        Layout.fillWidth: true
+        Layout.preferredHeight: 20 * count
+
+        clip: true
+
+        function eventTriggered(message) {
+            let obj = eventDelegateComponent.createObject()
+            obj.text = message
+            model.insert(0, obj)
+        }
+
+        Component {
+            id: eventDelegateComponent
+
+            ItemDelegate {
+                implicitHeight: 20
+
+                property int index: ObjectModel.index
+
+                Timer {
+                    interval: 5000; running: true
+                    onTriggered: testObjeModel.remove(index)
+                }
+            }
+        }
+
+        model: ObjectModel {
+            id: testObjeModel
+        }
     }
 
     StatusChatListItem {

--- a/sandbox/demoapp/StatusAppChatView.qml
+++ b/sandbox/demoapp/StatusAppChatView.qml
@@ -91,7 +91,7 @@ StatusAppThreePanelLayout {
                 anchors.horizontalCenter: parent.horizontalCenter
                 title: "Contact requests"
                 requestsCount: 3
-                sensor.onClicked: demoContactRequestsModal.open()
+                onClicked: demoContactRequestsModal.open()
             }
 
             StatusChatList {

--- a/src/StatusQ/Components/StatusChatList.qml
+++ b/src/StatusQ/Components/StatusChatList.qml
@@ -119,7 +119,7 @@ Column {
                     highlightWhenCreated: !!model.highlight
                     selected: (model.active && root.highlightItem)
 
-                    icon.emoji: model.emoji
+                    icon.emoji: !!model.emoji ? model.emoji : ""
                     icon.color: !!model.color ? model.color : Theme.palette.userCustomizationColors[model.colorId]
                     image.isIdenticon: false
                     image.source: model.icon

--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -32,7 +32,7 @@ Item {
     property bool draggableCategories: false
     // Keeps track of expanded category state. Should only be modified
     // internally at runtime.
-    property var openedCategoryState: new Object({})
+    property var openedCategoryState: ({})
 
     property Component categoryPopupMenu
     property Component chatListPopupMenu

--- a/src/StatusQ/Components/StatusChatListCategory.qml
+++ b/src/StatusQ/Components/StatusChatListCategory.qml
@@ -37,20 +37,20 @@ Column {
         title: statusChatListCategory.name
         opened: statusChatListCategory.opened
         sensor.pressAndHoldInterval: 150
-
+        propagateTitleClicks: true // title click is handled as a normal click (fallthru)
         showMenuButton: showActionButtons && !!statusChatListCategory.popupMenu
         highlighted: statusChatListCategory.dragged
-        sensor.onClicked: {
+        onClicked: {
             if (sensor.enabled) {
                 if (mouse.button === Qt.RightButton && showActionButtons && !!statusChatListCategory.popupMenu) {
                     highlighted = true;
                     popupMenuSlot.item.popup(mouse.x + 4, mouse.y + 6);
-                    return
+                } else if (mouse.button === Qt.LeftButton) {
+                    statusChatListCategory.opened = !statusChatListCategory.opened
                 }
             }
         }
-        onTitleClicked: statusChatListCategory.opened = !opened
-        onToggleButtonClicked: statusChatListCategory.opened = !opened
+        onToggleButtonClicked: statusChatListCategory.opened = !statusChatListCategory.opened
         onMenuButtonClicked: {
             highlighted = true
             menuButton.highlighted = true

--- a/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -60,15 +60,7 @@ StatusListItem {
             icon.name: "chevron-down"
             icon.width: 18
             icon.rotation: statusChatListCategoryItem.opened ? 0 : 270
-            onPressed: {
-                sensor.enabled = false;
-            }
-            onClicked: {
-                statusChatListCategoryItem.toggleButtonClicked(mouse);
-            }
-            onReleased: {
-                sensor.enabled = true;
-            }
+            onClicked: statusChatListCategoryItem.toggleButtonClicked(mouse)
         }
     ]
 }

--- a/src/StatusQ/Components/StatusChatListItem.qml
+++ b/src/StatusQ/Components/StatusChatListItem.qml
@@ -112,17 +112,14 @@ Rectangle {
 
             icon: {
                 switch (root.type) {
-                case StatusChatListItem.Type.PublicCat:
-                    return Theme.palette.name == "light" ? "tiny/public-chat" : "tiny/public-chat-white"
-                    break;
+                case StatusChatListItem.Type.PublicChat:
+                    return Theme.palette.name === "light" ? "tiny/public-chat" : "tiny/public-chat-white"
                 case StatusChatListItem.Type.GroupChat:
-                    return Theme.palette.name == "light" ? "tiny/group" : "tiny/group-white"
-                    break;
+                    return Theme.palette.name === "light" ? "tiny/group" : "tiny/group-white"
                 case StatusChatListItem.Type.CommunityChat:
-                    return Theme.palette.name == "light" ? "tiny/channel" : "tiny/channel-white"
-                    break;
+                    return Theme.palette.name === "light" ? "tiny/channel" : "tiny/channel-white"
                 default:
-                    return Theme.palette.name == "light" ? "tiny/public-chat" : "tiny/public-chat-white"
+                    return Theme.palette.name === "light" ? "tiny/public-chat" : "tiny/public-chat-white"
                 }
             }
         }

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -23,7 +23,6 @@ Rectangle {
     property string titleTextIcon: ""
     property real leftPadding: 16
     property real rightPadding: 16
-    property bool enabled: true
     property bool highlighted: false
     property bool propagateTitleClicks: true
     property int type: StatusListItem.Type.Primary
@@ -122,18 +121,20 @@ Rectangle {
     }
 
     MouseArea {
-        id: sensor
-
-        enabled: statusListItem.enabled
         anchors.fill: parent
-        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         acceptedButtons: Qt.LeftButton | Qt.RightButton
-        hoverEnabled: true
-        preventStealing: true
-
         onClicked: {
             statusListItem.clicked(statusListItem.itemId, mouse)
         }
+    }
+
+    MouseArea {
+        id: sensor
+
+        anchors.fill: parent
+        cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
+        acceptedButtons: Qt.NoButton
+        hoverEnabled: true
 
         StatusSmartIdenticon {
             id: iconOrImage
@@ -351,7 +352,7 @@ Rectangle {
             id: statusListItemLabel
             anchors.verticalCenter: bottomModel.length === 0 ? parent.verticalCenter : undefined
             anchors.top: bottomModel.length === 0 ? undefined:  parent.top
-            anchors.topMargin: bottomModel.length === 0 ? undefined : 16
+            anchors.topMargin: bottomModel.length === 0 ? 0 : 16
             anchors.right: statusListItemComponentsSlot.left
             anchors.rightMargin: statusListItemComponentsSlot.width > 0 ? 10 : 0
 


### PR DESCRIPTION
The culprit here is at the very bottom, in StatusListItem: the toplevel
item was a MouseArea handling the clicks and this causes problems as any
extra buttons placed on top of it get their mouseClick events delivered
in wrong order (after StatusListItem). Fix this by having a MouseArea
handling click events behind the actual toplevel item as a last resort,
catch all handler  plus the actual "sensor" being just a MouseArea that
handles merely the hover events

- drop unneeded onPressed/onReleased handlers in StatusChatListCategoryItem
- fix some warnings (typos, unreachable code, shadowed variables)

Fixes: status-im/status-desktop#6733

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
