### PR TITLE
fix(StatusSeedPhraseInput): fix notification of inserting word done

### DIFF
--- a/sandbox/pages/StatusInputPage.qml
+++ b/sandbox/pages/StatusInputPage.qml
@@ -69,9 +69,15 @@ Column {
             textEdit.input.anchors.leftMargin: 16
             textEdit.input.anchors.rightMargin: 16
             textEdit.input.anchors.topMargin: 11
-            textEdit.label: "Input with drop down selection list"
+            textEdit.label: "Input with drop down selection list" + (insertedWord ? ` (${insertedWord})` : "")
             leftComponentText: "1"
             inputList: ListModel {
+                ListElement {
+                    seedWord: "add"
+                }
+                ListElement {
+                    seedWord: "address"
+                }
                 ListElement {
                     seedWord: "panda"
                 }
@@ -79,9 +85,18 @@ Column {
                     seedWord: "posible"
                 }
                 ListElement {
+                    seedWord: "win"
+                }
+                ListElement {
+                    seedWord: "wine"
+                }
+                ListElement {
                     seedWord: "wing"
                 }
             }
+
+            property string insertedWord: ""
+            onDoneInsertingWord: insertedWord = word
         }
     }
 

--- a/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -99,7 +99,6 @@ Item {
     signal editClicked()
 
     function setWord(word) {
-        seedWordInput.ignoreTextChange = true
         seedWordInput.input.edit.text = word
     }
 
@@ -110,9 +109,8 @@ Item {
     }
 
     StatusInput {
-        property bool ignoreTextChange: false
-
         id: seedWordInput
+
         implicitWidth: parent.width
         input.leftComponent: StatusBaseText {
             rightPadding: 6
@@ -123,10 +121,6 @@ Item {
         }
         input.acceptReturn: true
         onTextChanged: {
-            if (ignoreTextChange) {
-                ignoreTextChange = false
-                return
-            }
             filteredList.clear();
             let textToCheck = text.trim()
             if (textToCheck !== "") {


### PR DESCRIPTION
Signal `doneInsertingWord` wasn't emitted when words was updated by adding one letter resulting in another valid word, e.g. `win` -> `wine`.

This PR withdraws part of the change introduced in https://github.com/status-im/StatusQ/pull/648. It should be tested carefully for regressions.

required by: https://github.com/status-im/status-desktop/issues/6619

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
