### PR TITLE
fix(StatusTabButton) adjust tab button height

### DIFF
--- a/src/StatusQ/Controls/StatusTabButton.qml
+++ b/src/StatusQ/Controls/StatusTabButton.qml
@@ -34,7 +34,7 @@ TabButton {
 
     contentItem: Item {
         implicitWidth: contentItemGrid.implicitWidth
-        implicitHeight: contentItemGrid.implicitHeight + 11
+        implicitHeight: contentItemGrid.implicitHeight + 15
 
         RowLayout {
             id: contentItemGrid


### PR DESCRIPTION
Needed by https://github.com/status-im/status-desktop/issues/6786

Required by https://github.com/status-im/status-desktop/pull/6914

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [X] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [X] test changes in [status-desktop](https://github.com/status-im/status-desktop)

![Screenshot from 2022-08-08 19-15-08](https://user-images.githubusercontent.com/6445843/183464342-177d14f2-11d6-4126-9419-b0c860fa5760.png)

![Screenshot from 2022-08-08 18-43-41](https://user-images.githubusercontent.com/6445843/183461967-554f723f-9a2c-45ea-a1ee-4e57ef7739ad.png)

