### PR TITLE
fix(StatusCommunityTags): fix width calculation

### DIFF
--- a/src/StatusQ/Components/StatusCommunityTags.qml
+++ b/src/StatusQ/Components/StatusCommunityTags.qml
@@ -13,21 +13,23 @@ Item {
     property alias model: repeater.model
     property alias contentWidth: flow.width
 
+    readonly property int itemsWidth: {
+        let result = 0;
+        for (let i = 0; i < repeater.count; ++i) {
+            result +=  flow.spacing + repeater.itemAt(i).width;
+        }
+        return result;
+    }
+
     signal clicked(var item)
 
-    implicitWidth: flow.implicitWidth
-    implicitHeight: flow.implicitHeight
+    implicitWidth: itemsWidth
+    implicitHeight: flow.height
 
     Flow {
         id: flow
         anchors.centerIn: parent
-        width: {
-            let itemsWidth = 0;
-            for (let i = 0; i < repeater.count; ++i) {
-                itemsWidth += spacing + repeater.itemAt(i).width;
-            }
-            return Math.min(parent.width, itemsWidth);
-        }
+        width: Math.min(parent.width, root.itemsWidth);
         spacing: 10
 
         Repeater {
@@ -38,7 +40,7 @@ Item {
                 name: model.name
                 visible: (root.showOnlySelected ? model.selected : !model.selected) &&
                          (filterString == 0 || name.toUpperCase().indexOf(filterString.toUpperCase()) !== -1)
-                width: visible ? implicitWidth : -10
+                width: visible ? implicitWidth : -flow.spacing
                 height: visible ? implicitHeight : 0
                 removable: root.showOnlySelected && root.active
                 onClicked: root.clicked(model)


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/pull/6917

https://user-images.githubusercontent.com/2522130/183500433-73dcd69e-d6ea-4272-8841-06eeebdc35af.mov


### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
