### PR TITLE
fix(StatusMenuItemDelegate): adjust menu item height

### DIFF
--- a/src/StatusQ/Popups/StatusMenuItemDelegate.qml
+++ b/src/StatusQ/Popups/StatusMenuItemDelegate.qml
@@ -9,7 +9,7 @@ import StatusQ.Popups 0.1
 MenuItem {
     id: statusPopupMenuItem
     implicitWidth: parent ? parent.width : 0
-    implicitHeight: action.enabled ? 38 : 0
+    implicitHeight: action.enabled ? 34 : 0
     objectName: action.objectName
 
     property int subMenuIndex


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/6830

Required by https://github.com/status-im/status-desktop/pull/6991

### Checklist

- [X] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [X] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [X] test changes in [status-desktop](https://github.com/status-im/status-desktop)

Design vs Sandbox app
![Screenshot from 2022-08-12 12-13-26](https://user-images.githubusercontent.com/6445843/184323986-a5ece0ca-6dd3-4714-8ce3-21463369af36.png)

Design vs Desktop app
![Screenshot from 2022-08-12 11-48-54](https://user-images.githubusercontent.com/6445843/184324117-072a394c-d1e6-43b4-bf84-71feded7f139.png)



