### PR TITLE
fix(StatusPopupMenu): update popup content to support big margins

### DIFF
--- a/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -13,6 +13,7 @@ Menu {
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
     topPadding: 8
     bottomPadding: 8
+    bottomMargin: 16
 
     property int menuItemCount: 0
     property var subMenuItemIcons: []
@@ -38,6 +39,13 @@ Menu {
 
     delegate: StatusMenuItemDelegate {
         statusPopupMenu: root
+    }
+
+    contentItem: StatusListView {
+        currentIndex: root.currentIndex
+        implicitHeight: contentHeight
+        interactive: contentHeight > availableHeight
+        model: root.contentModel
     }
 
     background: Item {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/6822

Required by https://github.com/status-im/status-desktop/pull/7011

### Checklist

- [X] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [X] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [X] test changes in [status-desktop](https://github.com/status-im/status-desktop)

Sandbox menu
https://user-images.githubusercontent.com/6445843/184596852-46ff5550-d08e-49fb-88cb-8a9ecc831973.mp4

Desktop app menu
https://user-images.githubusercontent.com/6445843/184597625-0507c476-4a2b-4bc1-91b5-16dd1b914a0b.mp4

Latest version with StatusListView
https://user-images.githubusercontent.com/6445843/184636538-6810ac03-5897-4d03-8e78-af973d589153.mp4



