### PR TITLE
fix(StatusChatListAndCategories): duplicate objectName

### DIFF
--- a/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -260,7 +260,6 @@ Item {
             }
 
             Repeater {
-                objectName: "statusChatListCategories"
                 id: statusChatListCategories
                 objectName: "communityChatListCategories"
                 visible: !!model && model.count > 0


### PR DESCRIPTION
Due to repository automerge.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
