### PR TITLE
fix(StatusInput)!: trigger errors bindings

### DIFF
--- a/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/src/StatusQ/Controls/StatusBaseInput.qml
@@ -182,9 +182,9 @@ Item {
 
     /*!
         \qmlproperty bool StatusBaseInput::valid
-        This property sets the valid state. Default value is true.
+        This property sets the valid state. Default value is false.
     */
-    property bool valid: true
+    property bool valid: false
     /*!
         \qmlproperty bool StatusBaseInput::pristine
         This property sets the pristine. Default value is true.

--- a/src/StatusQ/Controls/StatusInput.qml
+++ b/src/StatusQ/Controls/StatusInput.qml
@@ -48,6 +48,7 @@ Item {
         This property holds a reference to the TextEdit's valid property.
     */
     property alias valid: statusBaseInput.valid
+
     /*!
         \qmlproperty alias StatusInput::pending
         This property holds a reference to the TextEdit's pending property.
@@ -243,7 +244,7 @@ Item {
         This function resets the text input validation and text.
     */
     function reset() {
-        statusBaseInput.valid = true
+        statusBaseInput.valid = false
         statusBaseInput.pristine = true
         statusBaseInput.text = ""
         root.errorMessage = ""
@@ -276,8 +277,12 @@ Item {
                             valid: result
                         }
                     }
-                    result.errorMessage = validator.errorMessage
                     errors[validator.name] = result
+
+                    // the only way to trigger bindings for var property
+                    errors = errors
+                    result.errorMessage = validator.errorMessage
+
                     statusBaseInput.valid = statusBaseInput.valid && false
                 }
             }


### PR DESCRIPTION
add dirty alias

Fixes https://github.com/status-im/status-desktop/issues/6825

Needed by https://github.com/status-im/status-desktop/pull/7048

BREAKING CHANGE: StatusInput now emits signal for errors change

### Checklist

- [X] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [X] test changes in both light and dark theme?
- [x] is this a breaking change?
    - [X] use the dedicated `BREAKING CHANGE` commit message section
    - [x] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [x] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [X] test changes in [status-desktop](https://github.com/status-im/status-desktop)

Sandbox app
https://user-images.githubusercontent.com/6445843/184929450-25fdeaf9-093d-4b72-b493-198eaa08319e.mp4

Desktop app
https://user-images.githubusercontent.com/6445843/185091201-33872dc1-7115-49f7-a2c8-4eedc5b65ae5.mp4



