### PR TITLE
fix(StatusTabButton): display hand cursor on hover when enabled

### DIFF
--- a/src/StatusQ/Controls/StatusTabButton.qml
+++ b/src/StatusQ/Controls/StatusTabButton.qml
@@ -25,16 +25,20 @@ import StatusQ.Components 0.1
 TabButton {
     id: root
 
-    property alias badge: statusBadge
+    readonly property alias badge: statusBadge
 
     leftPadding: 12
     rightPadding: 12
 
     background: Item { }
 
-    contentItem: Item {
+    contentItem: MouseArea {
         implicitWidth: contentItemGrid.implicitWidth
         implicitHeight: contentItemGrid.implicitHeight + 15
+
+        cursorShape: Qt.PointingHandCursor
+        acceptedButtons: Qt.NoButton
+        enabled: root.enabled
 
         RowLayout {
             id: contentItemGrid


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/6787

StatusTabButton gains proper mouse cursor (hand) when active

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
