### PR TITLE
fix(StatusImageCropPanel): display SizeAllCursor cursor when over image

### DIFF
--- a/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -216,6 +216,7 @@ Item {
                 anchors.fill: parent
 
                 enabled: root.interactive
+                cursorShape: Qt.SizeAllCursor
 
                 property var lastDragPoint: null
                 onReleased: lastDragPoint = null


### PR DESCRIPTION
### Checklist

Sets the cursor shape to `Qt.SizeAllCursor` in `StatusImageCropPanel`.

Note: on Ubuntu there is a bug causing that Qt.SizeAllCursor is displayed as Qt.ClosedHandCursor cursor (tested on Qt 5.14, 5.15 and 6.3). It should be checked on Windows and Mac. If the problem exists only on linux I would suggest merging and reporting bug to Qt.

https://user-images.githubusercontent.com/20650004/185951283-36412a6a-c9fb-438d-8405-a56bef4718d8.mp4

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)
