### PR TITLE
chore(StatusAppNavBar): List views' bounds behavior refined

### DIFF
--- a/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -133,6 +133,7 @@ Rectangle {
                 anchors.bottom: separatorBottom.top
                 clip: true
 
+                boundsBehavior: contentHeight > height ? Flickable.DragAndOvershootBounds : Flickable.StopAtBounds
                 spacing: navBarButtonSpacing
 
                 model: navBarCommunityModel
@@ -167,6 +168,7 @@ Rectangle {
 
         spacing: navBarButtonSpacing
 
+        boundsBehavior: Flickable.StopAtBounds
         model: navBarModel
     }
 


### PR DESCRIPTION
### What does the PR do

This PR changes bounds behavior in StatusAppNavBar:

- outer list: not draggable
- communities list: not draggable when sufficient space,
  drag and overshot otherwise

Needed for https://github.com/status-im/status-desktop/issues/6805

https://user-images.githubusercontent.com/20650004/186013466-27cabb1f-ebcd-4adb-940f-078692e22829.mp4

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
