### PR TITLE
feat(StatusMessage): add `messageOriginInfo` property

### DIFF
--- a/src/StatusQ/Components/StatusMessage.qml
+++ b/src/StatusQ/Components/StatusMessage.qml
@@ -267,6 +267,7 @@ Rectangle {
                     Layout.fillWidth: true
                     sender: root.messageDetails.sender
                     amISender: root.messageDetails.amISender
+                    messageOriginInfo: root.messageDetails.messageOriginInfo
                     resendText: root.resendText
                     showResendButton: root.hasExpired && root.messageDetails.amISender
                     onClicked: root.senderNameClicked(sender, mouse)

--- a/src/StatusQ/Components/StatusMessageDetails.qml
+++ b/src/StatusQ/Components/StatusMessageDetails.qml
@@ -13,6 +13,7 @@ QtObject {
     property int contentType: 0
     property string messageText: ""
     property string messageContent: ""
+    property string messageOriginInfo: ""
 }
 
 

--- a/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml
+++ b/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml
@@ -23,6 +23,7 @@ Item {
     property bool isContact: sender.isContact
     property int trustIndicator: sender.trustIndicator
     property bool amISender: false
+    property string messageOriginInfo: ""
 
     signal clicked(var sender, var mouse)
     signal resendClicked()
@@ -56,6 +57,14 @@ Item {
                 }
             }
         }       
+        StatusBaseText {
+            id: messageOriginInfo
+            Layout.alignment: Qt.AlignVCenter
+            visible: root.messageOriginInfo !== ""
+            color: Theme.palette.baseColor1
+            font.pixelSize: 10
+            text: root.messageOriginInfo
+        }
         StatusContactVerificationIcons {
             visible: !root.amISender
             isContact: root.isContact
@@ -78,7 +87,7 @@ Item {
         }
         StatusBaseText {
             id: tertiaryDetailText
-            visible: !root.amISender
+            visible: !root.amISender && messageOriginInfo == ""
             Layout.alignment: Qt.AlignVCenter
             font.pixelSize: 10
             elide: Text.ElideMiddle


### PR DESCRIPTION
This is a property that allows for adding information about the origin
of a message (e.g. "Imported from discord").

This will most likely be only useful for messages that have been
imported from any other platform.

Because importing from other platforms requires those message to be
signed by a Status Account, it's undesirable to render the public key of
the account that signed imported messages.

Hence, when there's a `messageOriginInfo`, we don't render the elided
public key.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
