### PR TITLE
fix(StatusSelect): fix implicitWidth to account for content size

### DIFF
--- a/src/StatusQ/Controls/StatusSelect.qml
+++ b/src/StatusQ/Controls/StatusSelect.qml
@@ -23,6 +23,7 @@ Item {
     property var model
     property alias selectMenu: selectMenu
     property color bgColorHover: bgColor
+    // TODO: Fix the indirect handling of children
     property alias selectedItemComponent: selectedItemContainer.children
     property bool caretVisible: true
     property int caretRightMargin: 16
@@ -54,7 +55,7 @@ Item {
     Rectangle {
         property bool hovered: false
         id: inputRectangle
-        height: 56
+        height: selectedItemContainer.implicitHeight
         color: hovered ? bgColorHover : bgColor
         radius: 8
         anchors.top: root.hasLabel ? inputLabel.bottom : parent.top
@@ -64,7 +65,7 @@ Item {
         border.width: !!validationError ? 1 : 0
         border.color: Theme.palette.dangerColor1
 
-        Item {
+        GridLayout {
             id: selectedItemContainer
             anchors.fill: parent
         }


### PR DESCRIPTION
Fix space due to hardcoded width

![image](https://user-images.githubusercontent.com/47554641/187266883-19441ecd-8ff8-47b0-87b7-cb646ae5f12e.png)

## Breaking Change

Not used anywhere else in desktop app

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] ~~add documentation if necessary (new component, new feature)~~
- [x] ~~update sandbox app~~
- [x] test changes in both light and dark theme?
- [x] is this a breaking change?
    - [x] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
