### PR TITLE
fix(StatusRadioButton): radio button indicator centered

### DIFF
--- a/src/StatusQ/Controls/StatusRadioButton.qml
+++ b/src/StatusQ/Controls/StatusRadioButton.qml
@@ -29,8 +29,9 @@ RadioButton {
     indicator: Rectangle {
         implicitWidth: size === StatusRadioButton.Size.Large ? 20 : 14
         implicitHeight: size === StatusRadioButton.Size.Large ? 20 : 14
-        x: 0
-        y: 6
+
+        anchors.verticalCenter: parent.verticalCenter
+
         radius: 10
         color: statusRadioButton.checked ? Theme.palette.primaryColor1
                                          : Theme.palette.directColor8
@@ -39,8 +40,7 @@ RadioButton {
             width: size === StatusRadioButton.Size.Large ? 12 : 8
             height: size === StatusRadioButton.Size.Large ? 12 : 8
             radius: 6
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.centerIn: parent
             color: statusRadioButton.checked ? Theme.palette.white : "transparent"
             visible: statusRadioButton.checked
         }


### PR DESCRIPTION
Fix for indicator position in StatusRadioButton. The indicator wasn't vertically centered what resulted in improper location when using non-standard height.

Was:
![Screenshot from 2022-08-31 14-45-48](https://user-images.githubusercontent.com/20650004/187682285-b755724b-adba-4b6b-b81b-e0db9da9ffb9.png)

Is:
![Screenshot from 2022-08-31 14-47-22](https://user-images.githubusercontent.com/20650004/187682294-6d064695-c30f-47d8-964b-07cbcee1f7f7.png)

Needed for https://github.com/status-im/status-desktop/pull/7203

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
