### PR TITLE
feat(StatusMessage): introduce `profileClickable` property

### DIFF
--- a/src/StatusQ/Components/StatusMessage.qml
+++ b/src/StatusQ/Components/StatusMessage.qml
@@ -67,6 +67,7 @@ Rectangle {
     property bool hideQuickActions: false
     property color overrideBackgroundColor: "transparent"
     property bool overrideBackground: false
+    property bool profileClickable: true
 
     property alias previousMessageIndex: dateGroupLabel.previousMessageIndex
     property alias previousMessageTimestamp: dateGroupLabel.previousMessageTimestamp
@@ -242,9 +243,10 @@ Rectangle {
                     ringSettings: root.messageDetails.sender.profileImage.ringSettings
 
                     MouseArea {
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                         acceptedButtons: Qt.LeftButton | Qt.RightButton
                         anchors.fill: parent
+                        enabled: root.profileClickable
                         onClicked: root.profilePictureClicked(this, mouse)
                     }
                 }
@@ -275,6 +277,7 @@ Rectangle {
                     visible: root.showHeader && !editMode
                     timestamp.text: root.timestampString
                     timestamp.tooltip.text: root.timestampTooltipString
+                    displayNameClickable: root.profileClickable
                 }
                 Loader {
                     Layout.fillWidth: true

--- a/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml
+++ b/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml
@@ -23,6 +23,7 @@ Item {
     property bool isContact: sender.isContact
     property int trustIndicator: sender.trustIndicator
     property bool amISender: false
+    property bool displayNameClickable: true
     property string messageOriginInfo: ""
 
     signal clicked(var sender, var mouse)
@@ -49,8 +50,9 @@ Item {
             MouseArea {
                 id: mouseArea
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
+                cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                 acceptedButtons: Qt.LeftButton | Qt.RightButton
+                enabled: root.displayNameClickable
                 hoverEnabled: true
                 onClicked: {
                     root.clicked(this, mouse)


### PR DESCRIPTION
This property allows for enabling/disabling whether or not the profile
picture and display name of a message is clickable and also dictates the
cursor type accordingly.

The reason this is being introduced is that, with imported messages from
other systems (e.g. discord, telegram etc), we don't want the user to
trigger the popup menu for more profile information because we don't
know any profile information of messages coming from such systems.

Such messages are signed by the community.

Closes https://github.com/status-im/status-desktop/issues/6680

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
