### PR TITLE
feat(StatusMessageReply): introduce `profileClickable` property

### DIFF
--- a/src/StatusQ/Components/StatusMessage.qml
+++ b/src/StatusQ/Components/StatusMessage.qml
@@ -214,6 +214,7 @@ Rectangle {
             visible: active
             sourceComponent: StatusMessageReply {
                 replyDetails: root.replyDetails
+                profileClickable: root.profileClickable
                 onReplyProfileClicked: root.replyProfileClicked(sender, mouse)
                 audioMessageInfoText: root.audioMessageInfoText
             }

--- a/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -12,6 +12,7 @@ Item {
 
     property StatusMessageDetails replyDetails
     property string audioMessageInfoText: ""
+    property bool profileClickable: true
 
     signal replyProfileClicked(var sender, var mouse)
 
@@ -61,9 +62,10 @@ Item {
                     asset: replyDetails.sender.profileImage.assetSettings
                     ringSettings: replyDetails.sender.profileImage.ringSettings
                     MouseArea {
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                         acceptedButtons: Qt.LeftButton | Qt.RightButton
                         anchors.fill: parent
+                        enabled: root.profileClickable
                         onClicked: replyProfileClicked(this, mouse)
                     }
                 }


### PR DESCRIPTION
This is analogue to `profileClickable` available on `StatusMessage`,
preventing users to activate a reply-to-message's profile avatar.

At the time of this commit, this is only the case for imported messages.
So we can derive that, if `StatusMessage.profileClickable` is false, then
`StatusMessageReply.profileClickable` is also false.

Hence, we don't need to expose this property to higher level APIs.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
