### PR TITLE
fix(StatusBaseButton): keep `MouseArea` enabled when in `loading` state

### DIFF
--- a/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/src/StatusQ/Controls/StatusBaseButton.qml
@@ -89,7 +89,7 @@ Rectangle {
 
     color: {
         if (statusBaseButton.enabled)
-            return sensor.containsMouse || highlighted ? hoverColor
+            return !statusButton.loading && (sensor.containsMouse || highlighted) ? hoverColor
                                                        : normalColor;
         return disaledColor
     }
@@ -106,7 +106,7 @@ Rectangle {
                              : Qt.PointingHandCursor
 
         hoverEnabled: true
-        enabled: !loading && statusBaseButton.enabled
+        enabled: statusBaseButton.enabled
 
         Loader {
             anchors.centerIn: parent


### PR DESCRIPTION
`StatusBaseButton` comes with a `MouseArea` that is disabled when the button is set to being disabled. Prior to this commit it's *also* disabled when the button is in `loading` state.

This makes sense because a button that is in `loading` state shouldn't not emit any click signals or trigger hover indications.

There's a scenario though in which we want render a tooltip on top of the button which is in `loading` state. For the tooltip to show, the `MouseArea` of the button needs to be enabled.

Hence, this commit adjust `StatusBaseButton`'s behaviour to *not* disable the `MouseArea` when it's `loading`. Mouse events are already prevented via the `loading` flag. So the only thing left to do is to ensure the button doesn't trigger any hover indication when in `loading` state.

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
