### PR TITLE
feat(StatusItemSelector): improved reusablity, addItem and popup handling removed

### DIFF
--- a/sandbox/main.qml
+++ b/sandbox/main.qml
@@ -302,6 +302,11 @@ StatusWindow {
                         selected: viewLoader.source.toString().includes(title)
                         onClicked: mainPageView.page(title);
                     }
+                    StatusNavigationListItem {
+                        title: "StatusItemSelector"
+                        selected: viewLoader.source.toString().includes(title)
+                        onClicked: mainPageView.page(title, true);
+                    }
                     StatusListSectionHeadline { text: "StatusQ.Popup" }
                     StatusNavigationListItem {
                         title: "StatusPopupMenu"

--- a/sandbox/pages/StatusItemSelectorPage.qml
+++ b/sandbox/pages/StatusItemSelectorPage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.14
 import QtQuick.Layouts 1.14
 
 import StatusQ.Components 0.1
@@ -15,24 +15,43 @@ ColumnLayout {
         defaultItemText: "Example: Empty items"
         andOperatorText: "and"
         orOperatorText: "or"
-        popupItem: StatusDropdown {
+
+        itemsModel: ListModel {
+            id: model
+        }
+
+        StatusDropdown {
             id: dropdown
+
+            parent: selector.addButton
             width: 200
             contentItem: ColumnLayout {
                 spacing: 10
                 StatusInput {
                     id: input
+                    text: "Sample"
                     Layout.fillWidth: true
                 }
                 StatusButton {
                     Layout.alignment: Qt.AlignHCenter
                     text: "Add element"
                     onClicked: {
-                        selector.addItem(input.text, "qrc:/images/SNT.png", selector.itemsModel.count > 0 ? Utils.Operators.Or : Utils.Operators.None)
+                        model.append({
+                            text: input.text,
+                            imageSource: "qrc:/images/SNT.png",
+                            operator: model.count > 0 ? Utils.Operators.Or : Utils.Operators.None
+                        })
+
                         dropdown.close()
                     }
                 }
             }
+        }
+
+        addButton.onClicked: {
+            dropdown.x = mouse.x
+            dropdown.y = mouse.y
+            dropdown.open()
         }
     }
 

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -135,8 +135,7 @@ Rectangle {
             id: iconOrImage
             anchors.left: parent.left
             anchors.leftMargin: statusListItem.leftPadding
-            anchors.top: parent.top
-            anchors.topMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
             visible: !iconOrImageLoadingOverlay.visible
             asset: statusListItem.asset
             name: statusListItem.title

--- a/src/StatusQ/Components/StatusListItemTag.qml
+++ b/src/StatusQ/Components/StatusListItemTag.qml
@@ -6,8 +6,8 @@ import StatusQ.Core.Theme 0.1
 
 Rectangle {
     id: root
-    width: layout.width + layout.anchors.margins
-    height: 30
+    implicitWidth: layout.width + layout.anchors.margins
+    implicitHeight: 30
     color: Theme.palette.primaryColor3
     radius: 15
 
@@ -15,7 +15,7 @@ Rectangle {
 
     property string title: ""
     property bool closeButtonVisible: true
-    signal clicked()
+    signal clicked(var mouse)
 
     property StatusAssetSettings asset: StatusAssetSettings {
         height: 20
@@ -61,9 +61,7 @@ Rectangle {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    root.clicked()
-                }
+                onClicked: root.clicked(mouse)
             }
         }
     }


### PR DESCRIPTION
StatusItemSelector:
- no internal popup handling (better flexibility in terms of positioning)
- "add" button exposed
- onItemClicked signal added

Additionally:
- minor positioning fixes in StatusListItem and StatusListItemTag
- StatusItemSelectorPage updated and added to main.qml

needed for https://github.com/status-im/status-desktop/issues/6339, https://github.com/status-im/status-desktop/pull/7261

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
