### PR TITLE
fix(StatusListItem): adjust placement of title icons

### DIFF
--- a/sandbox/controls/ListItems.qml
+++ b/sandbox/controls/ListItems.qml
@@ -508,6 +508,14 @@ ColumnLayout {
     }
 
     StatusMemberListItem {
+        nickName: "untrusted-admin.eth"
+        asset.isLetterIdenticon: true
+        isUntrustworthy: true
+        isAdmin: true
+        isContact: true
+    }
+
+    StatusMemberListItem {
         nickName: "This girl I know from work"
         userName: "annabelle"
         asset.isLetterIdenticon: true

--- a/src/StatusQ/Components/StatusListItem.qml
+++ b/src/StatusQ/Components/StatusListItem.qml
@@ -175,7 +175,7 @@ Rectangle {
             anchors.left: iconOrImage.active ? iconOrImage.right : parent.left
             anchors.right: statusListItemLabel.visible ? statusListItemLabel.left : statusListItemComponentsSlot.left
             anchors.leftMargin: iconOrImage.active ? 16 : statusListItem.leftPadding
-            anchors.rightMargin: statusListItem.rightPadding
+            anchors.rightMargin: Math.max(statusListItem.rightPadding, titleIconsRow.requiredWidth)
             anchors.verticalCenter:  bottomModel.length === 0 ? parent.verticalCenter : undefined
 
             height: childrenRect.height
@@ -271,6 +271,9 @@ Rectangle {
 
             Loader {
                 id: titleIconsRow
+
+                readonly property int requiredWidth: active ? width + anchors.leftMargin * 2 : 0
+
                 anchors.left: !statusListItem.titleAsideText ? statusListItemTitle.right : statusListItemTitleAsideText.right
                 anchors.verticalCenter: statusListItemTitle.verticalCenter
                 anchors.leftMargin: 4


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/6972
Required by https://github.com/status-im/status-desktop/pull/7263

Update main area right margin to take in consideration big number of title icons

### Checklist

- [X] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [X] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [X] test changes in [status-desktop](https://github.com/status-im/status-desktop)

![Screenshot from 2022-09-07 16-25-34](https://user-images.githubusercontent.com/6445843/188891304-27551d75-9448-422e-85b3-a37c9ef7429a.png)
