### PR TITLE
fix: StatusDateGroupLabel doesn't support i18n and has no year

### DIFF
--- a/src/StatusQ/Components/StatusDateGroupLabel.qml
+++ b/src/StatusQ/Components/StatusDateGroupLabel.qml
@@ -18,37 +18,25 @@ StatusBaseText {
         if (previousMessageIndex === -1)
             return "";
 
-        const now = new Date()
-        const yesterday = new Date()
-        yesterday.setDate(now.getDate()-1)
-
         const currentMsgDate = new Date(messageTimestamp);
         const prevMsgDate = new Date(previousMessageTimestamp);
 
         if (!!prevMsgDate && currentMsgDate.getDay() === prevMsgDate.getDay())
             return "";
 
-        if (now == currentMsgDate)
+        const now = new Date();
+        if (now.getFullYear() == currentMsgDate.getFullYear() && now.getMonth() == currentMsgDate.getMonth() && now.getDate() == currentMsgDate.getDate())
             return qsTr("Today");
 
-        if (yesterday == currentMsgDate)
+        const yesterday = new Date();
+        yesterday.setDate(now.getDate()-1);
+        if (yesterday.getFullYear() == currentMsgDate.getFullYear() && yesterday.getMonth() == currentMsgDate.getMonth() && yesterday.getDate() == currentMsgDate.getDate())
             return qsTr("Yesterday");
 
-        const monthNames = [
-                             qsTr("January"),
-                             qsTr("February"),
-                             qsTr("March"),
-                             qsTr("April"),
-                             qsTr("May"),
-                             qsTr("June"),
-                             qsTr("July"),
-                             qsTr("August"),
-                             qsTr("September"),
-                             qsTr("October"),
-                             qsTr("November"),
-                             qsTr("December")
-                         ];
-
-        return monthNames[currentMsgDate.getMonth()] + ", " + currentMsgDate.getDate();
+        // FIXME Qt6: replace with Intl.DateTimeFormat
+        const monthName = Qt.locale().standaloneMonthName(currentMsgDate.getMonth(), Locale.LongFormat)
+        if (now.getFullYear() > currentMsgDate.getFullYear())
+            return "%1 %2, %3".arg(monthName).arg(currentMsgDate.getDate()).arg(currentMsgDate.getFullYear())
+        return "%1, %2".arg(monthName).arg(currentMsgDate.getDate())
     }
 }


### PR DESCRIPTION
- fix evaluating "Today" and "Yesterday"; can't just compare the two Date objects, the timestamp will always differ so need to compare year/month/day only
- best attempt to have the month translated, and year added if they differ (until Qt6 at least, left a TODO)

Closes #843

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)

### Screenshots
A translated date + "Yesterday" shown:
![Snímek obrazovky z 2022-09-08 11-01-22](https://user-images.githubusercontent.com/5377645/189081571-e909b084-80f6-4e7e-9fd8-c00a5d244988.png)

Today/yesterday fixed:
![Snímek obrazovky z 2022-09-08 11-00-15](https://user-images.githubusercontent.com/5377645/189081577-ec776ed3-d0e8-4f1b-bf6c-26de208d9935.png)

