### PR TITLE
chore(StatusItemSelector): allow of using icons

### DIFF
--- a/src/StatusQ/Components/StatusItemSelector.qml
+++ b/src/StatusQ/Components/StatusItemSelector.qml
@@ -95,6 +95,12 @@ Rectangle {
     */
     property var itemsModel: ListModel { }
     /*!
+       \qmlproperty bool StatusItemSelector::useIcons
+       This property determines if the imageSource role from the model will be handled as
+       an image or an icon.
+    */
+    property bool useIcons: false
+    /*!
        \qmlproperty string StatusItemSelector::andOperatorText
        This property holds the string text representation for an `AND` logical operator.
     */
@@ -168,7 +174,7 @@ Rectangle {
             Layout.fillWidth: true
             spacing: 6
             StatusListItemTag {
-                visible: itemsModel.count === 0
+                visible: !itemsModel || itemsModel.count === 0
                 title: root.defaultItemText
                 asset.name: root.defaultItemImageSource
                 asset.isImage: true
@@ -204,7 +210,8 @@ Rectangle {
                     StatusListItemTag {
                         title: model.text
                         asset.name: model.imageSource
-                        asset.isImage: true
+                        asset.isImage: !root.useIcons
+                        asset.bgColor: "transparent"
                         color: Theme.palette.primaryColor3
                         closeButtonVisible: false
                         titleText.color: Theme.palette.primaryColor1


### PR DESCRIPTION
Gives possibility to use icons in StatusItemSelector.

Required by: https://github.com/status-im/status-desktop/issues/6040

### Checklist

- [ ] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [x] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
