### PR TITLE
hotfix: unbreak "pointing hand" cursor

### DIFF
--- a/sandbox/controls/Buttons.qml
+++ b/sandbox/controls/Buttons.qml
@@ -27,12 +27,18 @@ Column {
                 text: "Look I'm a tooltip on a button!"
             }
             onClicked: console.warn("Primary button clicked")
+            onPressed: console.warn("Primary button pressed")
         }
 
         StatusButton {
             text: "Button"
             enabled: false
             type: StatusBaseButton.Type.Primary
+
+            StatusToolTip {
+                visible: parent.hovered
+                text: "Tooltip on a disabled button, should not be visible!"
+            }
             onClicked: console.warn("Primary disabled button clicked, this should not happen !!!")
         }
 

--- a/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/src/StatusQ/Controls/StatusBaseButton.qml
@@ -63,6 +63,8 @@ Button {
         }
     }
 
+    spacing: root.size === StatusBaseButton.Size.Large ? 6 : 4
+
     icon.height: 24
     icon.width: 24
 
@@ -74,16 +76,10 @@ Button {
                 return !root.loading && (root.hovered || root.highlighted) ? hoverColor : normalColor;
             return disabledColor;
         }
-        MouseArea {
-            anchors.fill: parent
-            enabled: root.enabled
-            acceptedButtons: Qt.NoButton
-            cursorShape: root.loading ? Qt.ArrowCursor : Qt.PointingHandCursor
-        }
     }
 
     contentItem: RowLayout {
-        spacing: root.size === StatusBaseButton.Size.Large ? 6 : 4
+        spacing: root.spacing
         StatusIcon {
             Layout.preferredWidth: visible ? root.icon.width : 0
             Layout.preferredHeight: visible ? root.icon.height : 0
@@ -123,8 +119,8 @@ Button {
         anchors.fill: parent
         acceptedButtons: Qt.AllButtons
         enabled: root.loading
-        hoverEnabled: enabled
         onPressed: mouse.accepted = true
         onWheel: wheel.accepted = true
+        cursorShape: !root.loading ? Qt.PointingHandCursor: undefined // always works; 'undefined' resets to default cursor
     }
 }


### PR DESCRIPTION
turns out we can indeed have only one MouseArea to handle both the cursor and intercepting the event in the "loading" state

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
