### PR TITLE
fix(StatusChatInfoButton): pinned messages counter

### DIFF
--- a/sandbox/controls/Controls.qml
+++ b/sandbox/controls/Controls.qml
@@ -150,13 +150,13 @@ GridLayout {
         implicitHeight: 48
         StatusChatInfoButton {
             title: "Iuri Matias elided"
-            subTitle: "Contact"
+            subTitle: "Very long subtitle should elide as well"
             asset.color: Theme.palette.miscColor7
             asset.isImage: true
             asset.name: "qrc:/demoapp/data/profile-image-1.jpeg"
             type: StatusChatInfoButton.Type.OneToOneChat
             muted: true
-            pinnedMessagesCount: 1
+            pinnedMessagesCount: 10
             width: 100
         }
     }
@@ -197,6 +197,14 @@ GridLayout {
         subTitle: "Community Chat"
         asset.color: Theme.palette.miscColor7
         type: StatusChatInfoButton.Type.CommunityChat
+    }
+
+    StatusChatInfoButton {
+        title: "community-channel"
+        subTitle: "Some very long description text to see how the whole item wraps or elides"
+        asset.color: Theme.palette.miscColor7
+        type: StatusChatInfoButton.Type.CommunityChat
+        pinnedMessagesCount: 3
     }
 
     StatusSlider {

--- a/sandbox/controls/Layout.qml
+++ b/sandbox/controls/Layout.qml
@@ -28,8 +28,8 @@ Column {
 
         headerContent: StatusChatInfoButton {
             width: Math.min(implicitWidth, parent.width)
-            title: "Some contact"
-            subTitle: "Contact"
+            title: "Muted public chat"
+            subTitle: "Some subtitle"
             asset.color: Theme.palette.miscColor7
             type: StatusChatInfoButton.Type.PublicChat
             pinnedMessagesCount: 1
@@ -44,11 +44,32 @@ Column {
 
         headerContent: StatusChatInfoButton {
             width: Math.min(implicitWidth, parent.width)
-            title: "Some contact"
-            subTitle: "Contact"
+            title: "Group chat"
+            subTitle: "Group chat subtitle"
             asset.color: Theme.palette.miscColor7
-            type: StatusChatInfoButton.Type.OneToOneChat
+            type: StatusChatInfoButton.Type.GroupChat
             pinnedMessagesCount: 1
+        }
+    }
+
+    StatusToolBar {
+        width: 518
+
+        headerContent: StatusChatInfoButton {
+            title: "Community chat"
+            subTitle: "Some very long description text to see how the whole item wraps or ellides"
+            asset.color: Theme.palette.miscColor7
+            type: StatusChatInfoButton.Type.CommunityChat
+            pinnedMessagesCount: 3
+        }
+    }
+
+    StatusToolBar {
+        headerContent: StatusChatInfoButton {
+            title: "Very long chat name"
+            asset.color: Theme.palette.miscColor7
+            type: StatusChatInfoButton.Type.CommunityChat
+            pinnedMessagesCount: 1234567891
         }
     }
 
@@ -473,8 +494,5 @@ Column {
                 }
             }
         }
-
-
     }
 }
-


### PR DESCRIPTION
- fix the "pinned messages" counter; resort to showing just the number in case of constrained space
- add plural handling (Fixes #899)
- modernize using layouts (Fixes #898)
- add some more examples

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [ ] test changes in [status-desktop](https://github.com/status-im/status-desktop)

### Screenshots
![Snímek obrazovky z 2022-09-13 15-06-40](https://user-images.githubusercontent.com/5377645/189910010-e5a95794-3796-41ec-a527-dfdd28f74eec.png)

![Snímek obrazovky z 2022-09-13 15-07-17](https://user-images.githubusercontent.com/5377645/189910005-81344b84-9928-4d99-bd1b-3df334337f9d.png)
