### PR TITLE
fix(StatusBaseButton): font family and weight fixed

### DIFF
--- a/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/src/StatusQ/Controls/StatusBaseButton.qml
@@ -42,6 +42,7 @@ Button {
         readonly property color textColor: root.enabled || root.loading ? root.textColor : root.disabledTextColor
     }
 
+    font.family: Theme.palette.baseFont.name
     font.weight: Font.Medium
     font.pixelSize: size === StatusBaseButton.Size.Large ? 15 : 13
 

--- a/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.13
 
 QtObject {
-
     id: theme
 
     property string name
@@ -10,88 +9,95 @@ QtObject {
         source: "../../../assets/fonts/Inter/Inter-Regular.otf"
     }
 
-    property var baseFontThin: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-Thin.otf"
-    }
-
-    property var baseFontExtraLight: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-ExtraLight.otf"
-    }
-
-    property var baseFontLight: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-Light.otf"
-    }
-
-    property var baseFontMedium: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-Medium.otf"
-    }
-
-    property var baseFontBold: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-Bold.otf"
-    }
-
-    property var baseFontExtraBold: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-ExtraBold.otf"
-    }
-
-    property var baseFontBlack: FontLoader {
-        source: "../../../assets/fonts/Inter/Inter-Black.otf"
-    }
-
     property var monoFont: FontLoader {
         source: "../../../assets/fonts/InterStatus/InterStatus-Regular.otf"
-    }
-
-    property var monoFontThin: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-Thin.otf"
-    }
-
-    property var monoFontExtraLight: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraLight.otf"
-    }
-
-    property var monoFontLight: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-Light.otf"
-    }
-
-    property var monoFontMedium: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-Medium.otf"
-    }
-
-    property var monoFontBold: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-Bold.otf"
-    }
-
-    property var monoFontExtraBold: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-ExtraBold.otf"
-    }
-
-    property var monoFontBlack: FontLoader {
-        source: "../../../assets/fonts/InterStatus/InterStatus-Black.otf"
     }
 
     property var codeFont: FontLoader {
         source: "../../../assets/fonts/RobotoMono/RobotoMono-Regular.ttf"
     }
 
-    property var codeFontThin: FontLoader {
-        source: "../../../assets/fonts/RobotoMono/RobotoMono-Thin.ttf"
-    }
+    readonly property QtObject _d: QtObject {
+        // specific font variants should not be accessed directly
 
-    property var codeFontExtraLight: FontLoader {
-        source: "../../../assets/fonts/RobotoMono/RobotoMono-ExtraLight.ttf"
-    }
+        // Inter font variants
+        property var baseFontThin: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-Thin.otf"
+        }
 
-    property var codeFontLight: FontLoader {
-        source: "../../../assets/fonts/RobotoMono/RobotoMono-Light.ttf"
-    }
+        property var baseFontExtraLight: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-ExtraLight.otf"
+        }
 
-    property var codeFontMedium: FontLoader {
-        source: "../../../assets/fonts/RobotoMono/RobotoMono-Medium.ttf"
-    }
+        property var baseFontLight: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-Light.otf"
+        }
 
-    property var codeFontBold: FontLoader {
-        source: "../../../assets/fonts/RobotoMono/RobotoMono-Bold.ttf"
+        property var baseFontMedium: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-Medium.otf"
+        }
+
+        property var baseFontBold: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-Bold.otf"
+        }
+
+        property var baseFontExtraBold: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-ExtraBold.otf"
+        }
+
+        property var baseFontBlack: FontLoader {
+            source: "../../../assets/fonts/Inter/Inter-Black.otf"
+        }
+
+        // Inter Status font variants
+        property var monoFontThin: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-Thin.otf"
+        }
+
+        property var monoFontExtraLight: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-ExtraLight.otf"
+        }
+
+        property var monoFontLight: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-Light.otf"
+        }
+
+        property var monoFontMedium: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-Medium.otf"
+        }
+
+        property var monoFontBold: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-Bold.otf"
+        }
+
+        property var monoFontExtraBold: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-ExtraBold.otf"
+        }
+
+        property var monoFontBlack: FontLoader {
+            source: "../../../assets/fonts/InterStatus/InterStatus-Black.otf"
+        }
+
+        // Roboto font variants
+        property var codeFontThin: FontLoader {
+            source: "../../../assets/fonts/RobotoMono/RobotoMono-Thin.ttf"
+        }
+
+        property var codeFontExtraLight: FontLoader {
+            source: "../../../assets/fonts/RobotoMono/RobotoMono-ExtraLight.ttf"
+        }
+
+        property var codeFontLight: FontLoader {
+            source: "../../../assets/fonts/RobotoMono/RobotoMono-Light.ttf"
+        }
+
+        property var codeFontMedium: FontLoader {
+            source: "../../../assets/fonts/RobotoMono/RobotoMono-Medium.ttf"
+        }
+
+        property var codeFontBold: FontLoader {
+            source: "../../../assets/fonts/RobotoMono/RobotoMono-Bold.ttf"
+        }
     }
 
     property color black: getColor('black')


### PR DESCRIPTION
### Checklist

Font family set for StatusBaseButton, font variants moved to internal object to avoid accessing them directly.

In the future we should consider switching to variable fonts in order to avoid loading multiple font variants.

![Screenshot 2022-09-15 16:25:12](https://user-images.githubusercontent.com/20650004/190430376-33e34403-76c6-4c5e-82ac-ef6126b94b95.png)

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
