### PR TITLE
feat(StatusMessage): add 'hideMessage' property to allow hiding main message text

### DIFF
--- a/src/StatusQ/Components/StatusMessage.qml
+++ b/src/StatusQ/Components/StatusMessage.qml
@@ -69,6 +69,7 @@ Rectangle {
     property color overrideBackgroundColor: "transparent"
     property bool overrideBackground: false
     property bool profileClickable: true
+    property bool hideMessage: false
 
     property alias previousMessageIndex: dateGroupLabel.previousMessageIndex
     property alias previousMessageTimestamp: dateGroupLabel.previousMessageTimestamp
@@ -264,6 +265,7 @@ Rectangle {
             }
 
             ColumnLayout {
+
                 spacing: 4
                 Layout.alignment: Qt.AlignTop
                 Layout.fillWidth: true
@@ -292,7 +294,7 @@ Rectangle {
                 }
                 Loader {
                     Layout.fillWidth: true
-                    active: !editMode && !!root.messageDetails.messageText
+                    active: !root.editMode && !!root.messageDetails.messageText && !root.hideMessage
                     visible: active
                     sourceComponent: StatusTextMessage {
                         objectName: "StatusMessage_textMessage"


### PR DESCRIPTION
This functionality is needed to hide image links when image is unfurled.

Needed for: https://github.com/status-im/status-desktop/pull/7452

### Checklist

- [x] follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - the scope should be the component's name e.g: `feat(StatusListItem): ... `
  - when adding new components, the scope is the module e.g: `feat(StatusQ.Controls): ...`
- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
- [ ] is this a breaking change?
    - [ ] use the dedicated `BREAKING CHANGE` commit message section
    - [ ] resolve breaking changes in [status-desktop](https://github.com/status-im/status-desktop)
        - [ ] (pre-merge) adapt code to breaking changes
        - [ ] (post-merge) update StatusQ submodule pointer
- [x] test changes in [status-desktop](https://github.com/status-im/status-desktop)
